### PR TITLE
Rename TxParser.new() to TxParser._new()

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,7 +35,7 @@ const obj = {
       treeParams = Params.fromBinaryExtended(new Uint8Array(treeParamsData!), false, false);
     }
 
-    txParser = TxParser.new()
+    txParser = TxParser._new()
     console.info('Web worker init complete.');
   },
 


### PR DESCRIPTION
It is neccessary since wasm-bindgen v0.2.82 adds underscore prefix to method names equal to JS keywords.
PR: https://github.com/rustwasm/wasm-bindgen/pull/2855 