### PR TITLE
Feature/params loading progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "regenerator-runtime": "^0.13.9",
     "web3": "^1.7.0",
     "ethereumjs-util": "^7.1.5",
-    "web3-utils": "^1.7.0"
+    "web3-utils": "^1.7.0",
+    "fast-sha256": "^1.3.0"
   },
   "devDependencies": {
     "ts-loader": "^9.2.6",

--- a/src/file-cache.ts
+++ b/src/file-cache.ts
@@ -15,9 +15,12 @@ export class FileCache {
 
   static async init(): Promise<FileCache> {
     const db = await openDB('zp.file_cache', 2, {
-      upgrade(db) {
-        db.createObjectStore(STORE_FILES);
-        db.createObjectStore(STORE_HASHES);
+      upgrade(db, oldVersion, newVersions) {
+        if (oldVersion == 0) {
+          db.createObjectStore(STORE_FILES);
+        } else if (oldVersion == 1) {
+          db.createObjectStore(STORE_HASHES);
+        }
       }
     });
 

--- a/src/file-cache.ts
+++ b/src/file-cache.ts
@@ -1,5 +1,7 @@
 import { openDB, IDBPDatabase } from 'idb';
 
+export type LoadingProgressCallback = (loadedBytes: number, totalBytes: number) => void;
+
 const STORE_NAME = 'files';
 
 export class FileCache {
@@ -20,7 +22,7 @@ export class FileCache {
     return cache;
   }
 
-  public async getOrCache(path: string): Promise<ArrayBuffer> {
+  public async getOrCache(path: string, loadingCallback: LoadingProgressCallback | undefined = undefined): Promise<ArrayBuffer> {
     let data = await this.get(path);
     if (!data) {
       console.log(`Caching ${path}`)
@@ -32,7 +34,59 @@ export class FileCache {
     return data;
   }
 
-  public async cache(path: string): Promise<ArrayBuffer> {
+  public async cache(path: string, loadingCallback: LoadingProgressCallback | undefined = undefined): Promise<ArrayBuffer> {
+    let response = await fetch(path);
+
+    if (response.body) {
+      const reader = response.body.getReader();  
+      
+      // Total file length
+      const totalBytes = Number(response.headers.get('Content-Length'));
+
+      // Reading the data chunks
+      let loadedBytes = 0; // received that many bytes at the moment
+      let chunks: Array<Uint8Array> = []; // array of received binary chunks (comprises the body)
+      while(true) {
+        const res = await reader.read();
+
+        if (res.done) {
+          break;
+        }
+
+        if (res.value !== undefined) {
+          chunks.push(res.value);
+          loadedBytes += res.value.length;
+
+          if (loadingCallback !== undefined) {
+            loadingCallback(loadedBytes, totalBytes)
+          }
+          console.log(`Received ${loadedBytes} of ${totalBytes} (${(loadedBytes / totalBytes) * 100.0} %)`)
+        }
+      }
+
+      console.log(`Concatenating chunks...`);
+
+      // Concatenate data chunks into single Uint8Array
+      let chunksAll = new Uint8Array(loadedBytes);
+      let position = 0;
+      for(let chunk of chunks) {
+        chunksAll.set(chunk, position); // (4.2)
+        position += chunk.length;
+      }
+
+      console.log(`Saving buffer to the database`);
+
+      const data = chunksAll.buffer;
+      await this.db.put(STORE_NAME, data, path);
+
+      console.log(`Parameter file loaded`);
+
+      return data;
+
+    } else {
+      throw Error(`Cannot get response body for ${path}`);
+    }
+
     const data = await (await fetch(path)).arrayBuffer();
     await this.db.put(STORE_NAME, data, path);
     return data;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,24 @@ export { TxType } from './tx';
 
 export { HistoryRecord, HistoryTransactionType } from './history'
 
+
+export enum InitState {
+  Started = 1,
+  DownloadingParams,
+  InitWorker,
+  InitWasm,
+  Completed,
+  Failed,
+}
+
+export interface InitStatus {
+  state: InitState;
+  download: {loaded: number, total: number};  // bytes
+  error?: Error | undefined;
+}
+
+export type InitLibCallback = (status: InitStatus) => void;
+
 export class ZkBobLibState {
   public fileCache: FileCache;
   public worker: any;
@@ -21,9 +39,16 @@ export async function init(
   wasmPath: string,
   workerPath: string,
   snarkParams: SnarkConfigParams,
-  loadingCallback: LoadingProgressCallback | undefined = undefined 
+  statusCallback: InitLibCallback | undefined = undefined 
 ): Promise<ZkBobLibState> {
   const fileCache = await FileCache.init();
+
+  let lastProgress = {loaded: -1, total: -1};
+
+  if (statusCallback !== undefined) {
+    // Start initialization event
+    statusCallback({ state: InitState.Started, download: lastProgress });
+  }
 
   let loaded = false;
   const worker: any = wrap(new Worker(workerPath));
@@ -37,26 +62,28 @@ export async function init(
     loaded = true
   });
 
-  if (loadingCallback !== undefined) {
+  if (statusCallback !== undefined) {
     // progress pseudo callback
-    let lastLoadedBytes = -1;
     while (loaded == false) {
       const progress = await worker.getProgress();
-      if (progress.total > 0 && progress.loaded != lastLoadedBytes) {
-        loadingCallback(progress.loaded, progress.total);
-        lastLoadedBytes = progress.loaded;
+      if (progress.total > 0 && progress.loaded != lastProgress.loaded) {
+        lastProgress = progress;
+        statusCallback({ state: InitState.DownloadingParams, download: lastProgress });
       }
 
       await new Promise(resolve => setTimeout(resolve, 10));
     }
 
-    const progress = await worker.getProgress();
-    loadingCallback(progress.loaded, progress.total);
+    lastProgress = await worker.getProgress();
+    statusCallback({ state: InitState.DownloadingParams, download: lastProgress });
   }
 
+  console.log(`Wasm engine initializing`);
   await initWasm(wasmPath);
+  console.log(`Download verification keys`);
   const transferVk = await (await fetch(snarkParams.transferVkUrl)).json();
   const treeVk = await (await fetch(snarkParams.treeVkUrl)).json();
+  console.log(`Finishing library initialization`);
 
   return {
     fileCache,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Params, default as initWasm } from 'libzkbob-rs-wasm-web';
 
 import { SnarkConfigParams, SnarkParams } from './config';
 import { FileCache } from './file-cache';
+import { LoadingProgressCallback } from './file-cache';
 
 export { ZkBobClient, TxAmount, FeeAmount, PoolLimits } from './client';
 
@@ -16,13 +17,19 @@ export class ZkBobLibState {
   public snarkParams: SnarkParams;
 }
 
-export async function init(wasmPath: string, workerPath: string, snarkParams: SnarkConfigParams): Promise<ZkBobLibState> {
+export async function init(
+  wasmPath: string,
+  workerPath: string,
+  snarkParams: SnarkConfigParams,
+  loadingCallback: LoadingProgressCallback | undefined = undefined 
+): Promise<ZkBobLibState> {
   const fileCache = await FileCache.init();
 
   const worker: any = wrap(new Worker(workerPath));
   await worker.initWasm(wasmPath, {
     txParams: snarkParams.transferParamsUrl,
     treeParams: snarkParams.treeParamsUrl,
+    loadingCallback
   });
 
   await initWasm(wasmPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export async function init(
       const progress = await worker.getProgress();
       if (progress.total > 0 && progress.loaded != lastLoadedBytes) {
         loadingCallback(progress.loaded, progress.total);
-        lastLoadedBytes = progress.loading;
+        lastLoadedBytes = progress.loaded;
       }
 
       await new Promise(resolve => setTimeout(resolve, 10));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,9 @@
 import { wrap } from 'comlink';
 import { Params, default as initWasm } from 'libzkbob-rs-wasm-web';
-
 import { SnarkConfigParams, SnarkParams } from './config';
 import { FileCache } from './file-cache';
-import { LoadingProgressCallback } from './file-cache';
-
 export { ZkBobClient, TxAmount, FeeAmount, PoolLimits } from './client';
-
 export { TxType } from './tx';
-
 export { HistoryRecord, HistoryTransactionType } from './history'
 
 
@@ -35,10 +30,19 @@ export class ZkBobLibState {
   public snarkParams: SnarkParams;
 }
 
+async function fetchTxParamsHash(relayerUrl: string): Promise<string> {
+  const url = new URL('/params/hash/tx', relayerUrl);
+  const headers = {'content-type': 'application/json;charset=UTF-8'};
+  const res = await fetch(url.toString(), {headers});
+
+  return (await res.json()).hash;
+}
+
 export async function init(
   wasmPath: string,
   workerPath: string,
   snarkParams: SnarkConfigParams,
+  relayerURL: string | undefined = undefined,
   statusCallback: InitLibCallback | undefined = undefined 
 ): Promise<ZkBobLibState> {
   const fileCache = await FileCache.init();
@@ -46,8 +50,16 @@ export async function init(
   let lastProgress = {loaded: -1, total: -1};
 
   if (statusCallback !== undefined) {
-    // Start initialization event
     statusCallback({ state: InitState.Started, download: lastProgress });
+  }
+
+  let txParamsHash: string | undefined = undefined;
+  if (relayerURL !== undefined) {
+    try {
+      txParamsHash = await fetchTxParamsHash(relayerURL);
+    } catch (err) {
+      console.warn(`Cannot fetch tx parameters hash from the relayer (${err.message})`);
+    }
   }
 
   let loaded = false;
@@ -55,7 +67,7 @@ export async function init(
   let initializer: Promise<void> = worker.initWasm(wasmPath, {
     txParams: snarkParams.transferParamsUrl,
     treeParams: snarkParams.treeParamsUrl,
-  });
+  }, txParamsHash);
 
   
   initializer.then(() => {
@@ -66,24 +78,42 @@ export async function init(
     // progress pseudo callback
     while (loaded == false) {
       const progress = await worker.getProgress();
-      if (progress.total > 0 && progress.loaded != lastProgress.loaded) {
-        lastProgress = progress;
-        statusCallback({ state: InitState.DownloadingParams, download: lastProgress });
+      const stage = await worker.getLoadingStage();
+      switch(stage) {
+        case 4: //LoadingStage.Download: // we cannot import LoadingStage in runtime
+          if (progress.total > 0 && progress.loaded != lastProgress.loaded) {
+            lastProgress = progress;
+            statusCallback({ state: InitState.DownloadingParams, download: lastProgress });
+          }
+          break;
+
+        case 5: //LoadingStage.LoadObjects: // we cannot import LoadingStage in runtime
+          lastProgress = progress;
+          statusCallback({ state: InitState.InitWorker, download: lastProgress });
+          break;
+
+        default: break;
       }
 
       await new Promise(resolve => setTimeout(resolve, 10));
     }
 
     lastProgress = await worker.getProgress();
-    statusCallback({ state: InitState.DownloadingParams, download: lastProgress });
+    statusCallback({ state: InitState.InitWasm, download: lastProgress });
   }
 
-  console.log(`Wasm engine initializing`);
+  console.time(`Wasm engine initializing`);
   await initWasm(wasmPath);
-  console.log(`Download verification keys`);
+  console.timeEnd(`Wasm engine initializing`);
+
+  console.time(`Load VKs`);
   const transferVk = await (await fetch(snarkParams.transferVkUrl)).json();
   const treeVk = await (await fetch(snarkParams.treeVkUrl)).json();
-  console.log(`Finishing library initialization`);
+  console.timeEnd(`Load VKs`);
+
+  if (statusCallback !== undefined) {
+    statusCallback({ state: InitState.Completed, download: lastProgress });
+  }
 
   return {
     fileCache,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,6 +100,20 @@ export function hexToBuf(hex: string, bytesCnt: number = 0): Uint8Array {
   return buffer;
 }
 
+export function isEqualBuffers(buf1: Uint8Array, buf2: Uint8Array): boolean {
+  if (buf1.length != buf2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < buf1.length; i++) {
+    if(buf1[i] != buf2[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 
 export class HexStringWriter {
   buf: string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,6 +6,16 @@ let txParams: Params;
 let treeParams: Params;
 let txParser: TxParser;
 
+enum LoadingStage {
+  Unknown = 0,
+  Init = 1,
+  Download,
+  CheckingHash,
+  LoadObjects,
+  Completed,
+}
+
+let loadingStage: LoadingStage = LoadingStage.Unknown;
 let loadedBytes: number = 0;
 let totalBytes: number = 0;
 
@@ -14,6 +24,7 @@ const obj = {
     url: string,
     paramUrls: { txParams: string; treeParams: string }
   ) {
+    loadingStage = LoadingStage.Init;
     console.info('Initializing web worker...');
     await init(url);
     await initThreadPool(navigator.hardwareConcurrency);
@@ -30,7 +41,9 @@ const obj = {
         loadedBytes = loaded;
         totalBytes = total;
       });
+      console.log(`Parameter file returned`);
       txParams = Params.fromBinary(new Uint8Array(txParamsData!));
+      console.log(`Parameter object created`);
     } else {
       loadedBytes = txParamsData.byteLength;
       totalBytes = txParamsData.byteLength;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,14 +1,17 @@
 import { expose } from 'comlink';
 import { Proof, Params, TxParser, IndexedTx, ParseTxsResult, default as init, initThreadPool } from 'libzkbob-rs-wasm-web';
-
-import { FileCache } from './file-cache';
+import { FileCache, LoadingProgressCallback } from './file-cache';
 
 let txParams: Params;
 let treeParams: Params;
 let txParser: TxParser;
 
 const obj = {
-  async initWasm(url: string, paramUrls: { txParams: string; treeParams: string }) {
+  async initWasm(
+    url: string,
+    paramUrls: { txParams: string; treeParams: string },
+    loadingCallback: LoadingProgressCallback | undefined = undefined
+  ) {
     console.info('Initializing web worker...');
     await init(url);
     await initThreadPool(navigator.hardwareConcurrency);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -71,32 +71,23 @@ const obj = {
       console.timeEnd(`Download params`);
 
       loadingStage = LoadingStage.LoadObjects;
-
+      await new Promise(resolve => setTimeout(resolve, 20)); // workaround to proper stage updating
       console.time(`Creating Params object`);
       txParams = Params.fromBinary(new Uint8Array(txParamsData!));
       console.timeEnd(`Creating Params object`);
-    } else {
-      loadingStage = LoadingStage.LoadObjects;
 
+    } else {
       loadedBytes = txParamsData.byteLength;
       totalBytes = txParamsData.byteLength;
 
       console.log(`File ${paramUrls.txParams} is present in cache, no need to fetch`);
 
+      loadingStage = LoadingStage.LoadObjects;
+      await new Promise(resolve => setTimeout(resolve, 20)); // workaround to proper stage updating
       console.time(`Creating Params object`);
       txParams = Params.fromBinaryExtended(new Uint8Array(txParamsData!), false, false);
       console.timeEnd(`Creating Params object`);
     }
-
-    /*let treeParamsData = await cache.get(paramUrls.treeParams);
-    if (!treeParamsData) {
-      console.log(`Caching ${paramUrls.treeParams}`)
-      treeParamsData = await cache.cache(paramUrls.treeParams, loadingCallback);
-      treeParams = Params.fromBinary(new Uint8Array(treeParamsData!));
-    } else {
-      console.log(`File ${paramUrls.treeParams} is present in cache, no need to fetch`);
-      treeParams = Params.fromBinaryExtended(new Uint8Array(treeParamsData!), false, false);
-    }*/
 
     txParser = TxParser._new()
     console.info('Web worker init complete.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,9 +993,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001400"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz#3038bee70d8b875604cd8833cb0e5e254ee0281a"
-  integrity sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==
+  version "1.0.30001409"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz#6135da9dcab34cd9761d9cdb12a68e6740c5e96e"
+  integrity sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1445,9 +1445,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.251:
-  version "1.4.251"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz#8b62448f3c591f0d32488df09454dda72dec96d5"
-  integrity sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ==
+  version "1.4.256"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz#c735032f412505e8e0482f147a8ff10cfca45bf4"
+  integrity sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==
 
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
@@ -2324,9 +2324,9 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
     safer-buffer ">= 2.1.2 < 3"
 
 idb@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/idb/-/idb-7.0.2.tgz#7a067e20dd16539938e456814b7d714ba8db3892"
-  integrity sha512-jjKrT1EnyZewQ/gCBb/eyiYrhGzws2FeY92Yx8qT9S9GeQAmo4JFVIiWRIfKW/6Ob9A+UDAOW9j9jn58fy2HIg==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.0.tgz#2cc886be57738419e57f9aab58f647e5e2160270"
+  integrity sha512-Wsk07aAxDsntgYJY4h0knZJuTxM73eQ4reRAO+Z1liOh8eMCJ/MoDS8fCui1vGT9mnjtl1sOu3I2i/W1swPYZg==
 
 idna-uts46-hx@^2.3.1:
   version "2.3.1"
@@ -4074,9 +4074,9 @@ tr46@~0.0.3:
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-loader@^9.2.6:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.3.1.tgz#fe25cca56e3e71c1087fe48dc67f4df8c59b22d4"
-  integrity sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.4.1.tgz#b6f3d82db0eac5a8295994f8cb5e4940ff6b1060"
+  integrity sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,9 +1445,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.251:
-  version "1.4.256"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz#c735032f412505e8e0482f147a8ff10cfca45bf4"
-  integrity sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==
+  version "1.4.257"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz#895dc73c6bb58d1235dc80879ecbca0bcba96e2c"
+  integrity sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A==
 
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
@@ -1900,6 +1900,11 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,9 +993,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001409"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz#6135da9dcab34cd9761d9cdb12a68e6740c5e96e"
-  integrity sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==
+  version "1.0.30001410"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001410.tgz#b5a86366fbbf439d75dd3db1d21137a73e829f44"
+  integrity sha512-QoblBnuE+rG0lc3Ur9ltP5q47lbguipa/ncNMyyGuqPk44FxbScWAeEO+k5fSQ8WekdAK4mWqNs1rADDAiN5xQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1445,9 +1445,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.251:
-  version "1.4.257"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz#895dc73c6bb58d1235dc80879ecbca0bcba96e2c"
-  integrity sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A==
+  version "1.4.258"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.258.tgz#44c5456f487be082f038282fbcfd7b06ae99720d"
+  integrity sha512-vutF4q0dTUXoAFI7Vbtdwen/BJVwPgj8GRg/SElOodfH7VTX+svUe62A5BG41QRQGk5HsZPB0M++KH1lAlOt0A==
 
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
@@ -1493,21 +1493,21 @@ envinfo@^7.7.3:
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
 
 es-abstract@^1.19.0, es-abstract@^1.19.5, es-abstract@^1.20.0:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.2.tgz#8495a07bc56d342a3b8ea3ab01bd986700c2ccb3"
-  integrity sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.3.tgz#90b143ff7aedc8b3d189bcfac7f1e3e3f81e9da1"
+  integrity sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     function.prototype.name "^1.1.5"
-    get-intrinsic "^1.1.2"
+    get-intrinsic "^1.1.3"
     get-symbol-description "^1.0.0"
     has "^1.0.3"
     has-property-descriptors "^1.0.0"
     has-symbols "^1.0.3"
     internal-slot "^1.0.3"
-    is-callable "^1.2.4"
+    is-callable "^1.2.6"
     is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
     is-shared-array-buffer "^1.0.2"
@@ -1517,6 +1517,7 @@ es-abstract@^1.19.0, es-abstract@^1.19.5, es-abstract@^1.20.0:
     object-keys "^1.1.1"
     object.assign "^4.1.4"
     regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
@@ -2071,7 +2072,7 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
   integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
@@ -2450,7 +2451,7 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.4:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.6.tgz#fd6170b0b8c7e2cc73de342ef8284a2202023c44"
   integrity sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==
@@ -3617,6 +3618,15 @@ safe-buffer@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"


### PR DESCRIPTION
Client library initialization callback and hash checking:

**Optional callback `statusCallback` has been added to the library `init` function**
It supports the following states: 
1. `Started` - reading params from DB, checking hash,
2. `DownloadingParams` - network loading tx parameters (`download` object will contain progress),
3. `InitWorker` - worker overhead (creating objects etc)
4. `InitWasm` - initialize wasm library and verification keys loading
5. `Completed` - Initialization has been finished without errors
6. `Failed` - error occured  (`error` field will set)

**Tree parameters loading (approx 10 Mb) was excluded from initialization**

**All internal errors are caught now and rollupped in `Failed` state**

**Tx params hash fetched from relayer and checked with saved one (if relayer associated method is available)**