### PR TITLE
Add ability to use delegated prover

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -608,7 +608,7 @@ export class ZkBobClient {
       const proofTime = (Date.now() - startProofDate) / 1000;
       console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
-      const txValid = await this.worker.verifyTxProof(txProof.inputs, txProof.proof);
+      const txValid = await this.worker.verifyTxProof(Object.values(txData.public), txProof.proof);
       if (!txValid) {
         throw new TxProofError();
       }
@@ -760,7 +760,7 @@ export class ZkBobClient {
       const proofTime = (Date.now() - startProofDate) / 1000;
       console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
-      const txValid = await this.worker.verifyTxProof(txProof.inputs, txProof.proof);
+      const txValid = await this.worker.verifyTxProof(Object.values(oneTxData.public), txProof.proof);
       if (!txValid) {
         throw new TxProofError();
       }
@@ -852,7 +852,7 @@ export class ZkBobClient {
       const proofTime = (Date.now() - startProofDate) / 1000;
       console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
-      const txValid = await this.worker.verifyTxProof(txProof.inputs, txProof.proof);
+      const txValid = await this.worker.verifyTxProof(Object.values(oneTxData.public), txProof.proof);
       if (!txValid) {
         throw new TxProofError();
       }
@@ -912,7 +912,7 @@ export class ZkBobClient {
     const proofTime = (Date.now() - startProofDate) / 1000;
     console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
-    const txValid = await this.worker.verifyTxProof(txProof.inputs, txProof.proof);
+    const txValid = await this.worker.verifyTxProof(Object.values(txData.public), txProof.proof);
     if (!txValid) {
       throw new TxProofError();
     }
@@ -992,7 +992,7 @@ export class ZkBobClient {
     const proofTime = (Date.now() - startProofDate) / 1000;
     console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
-    const txValid = await this.worker.verifyTxProof(txProof.inputs, txProof.proof);
+    const txValid = await this.worker.verifyTxProof(Object.values(txData.public), txProof.proof);
     if (!txValid) {
       throw new TxProofError();
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -998,7 +998,7 @@ export class ZkBobClient {
       console.debug('Delegated Prover: proveTx');
       try {
         const url = new URL('/proveTx', token.delegatedProverUrl);
-        const headers = {'content-type': 'application/json;charset=UTF-8'};
+        const headers = this.defaultHeaders();
         const proof = await this.fetchJson(url.toString(), { method: 'POST', headers, body: JSON.stringify({ public: pub, secret: sec }) });
         const inputs = Object.values(pub);
         const txValid = await this.worker.verifyTxProof(inputs, proof);

--- a/src/client.ts
+++ b/src/client.ts
@@ -2042,8 +2042,9 @@ export class ZkBobClient {
   }
 
   // TODO: make it configurable
-  private async proveTx(delegatedProverUrl, pub, sec): Promise<any> {
-    if (delegatedProverUrl !== undefined) {
+  private async proveTx(delegatedProverUrl: string | undefined, pub: any, sec: any): Promise<any> {
+    if (delegatedProverUrl) {
+      console.debug('Delegated Prover: proveTx');
       const url = new URL('/proveTx', delegatedProverUrl);
       const headers = {'content-type': 'application/json;charset=UTF-8'};
       return await this.fetchJson(url.toString(), { method: 'POST', headers, body: JSON.stringify({ public: pub, secret: sec }) });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1008,7 +1008,8 @@ export class ZkBobClient {
         return {inputs, proof};
       } catch (e) {
         if (token.proverMode == ProverMode.Delegated) {
-          throw new InternalError(`Failed to prove tx using delegated prover: ${e}`);
+          console.error(`Failed to prove tx using delegated prover: ${e}`);
+          throw new TxProofError();
         } else {
           console.warn(`Failed to prove tx using delegated prover: ${e}. Trying to prove with local prover...`);
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -584,7 +584,7 @@ export class ZkBobClient {
       }
 
       const startProofDate = Date.now();
-      const txProof = await this.worker.proveTx(txData.public, txData.secret);
+      const txProof = await this.proveTx(token.delegatedProverUrl, txData.public, txData.secret);
       const proofTime = (Date.now() - startProofDate) / 1000;
       console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
@@ -736,7 +736,7 @@ export class ZkBobClient {
       console.log(`Transaction created: delta_index = ${oneTxData.parsed_delta.index}, root = ${oneTxData.public.root}`);
 
       const startProofDate = Date.now();
-      const txProof: Proof = await this.worker.proveTx(oneTxData.public, oneTxData.secret);
+      const txProof: Proof = await this.proveTx(token.delegatedProverUrl, oneTxData.public, oneTxData.secret);
       const proofTime = (Date.now() - startProofDate) / 1000;
       console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
@@ -828,7 +828,7 @@ export class ZkBobClient {
       const oneTxData = await state.createWithdrawalOptimistic(oneTx, optimisticState);
 
       const startProofDate = Date.now();
-      const txProof: Proof = await this.worker.proveTx(oneTxData.public, oneTxData.secret);
+      const txProof: Proof = await this.proveTx(token.delegatedProverUrl, oneTxData.public, oneTxData.secret);
       const proofTime = (Date.now() - startProofDate) / 1000;
       console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
@@ -888,7 +888,7 @@ export class ZkBobClient {
     });
 
     const startProofDate = Date.now();
-    const txProof = await this.worker.proveTx(txData.public, txData.secret);
+    const txProof = await this.proveTx(token.delegatedProverUrl, txData.public, txData.secret);
     const proofTime = (Date.now() - startProofDate) / 1000;
     console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
@@ -968,7 +968,7 @@ export class ZkBobClient {
     const txData = await state.createTransfer({ outputs: outGwei, fee: feeGwei.toString() });
 
     const startProofDate = Date.now();
-    const txProof = await this.worker.proveTx(txData.public, txData.secret);
+    const txProof = await this.proveTx(token.delegatedProverUrl, txData.public, txData.secret);
     const proofTime = (Date.now() - startProofDate) / 1000;
     console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
@@ -2039,6 +2039,17 @@ export class ZkBobClient {
     } 
 
     return responseBody;
+  }
+
+  // TODO: make it configurable
+  private async proveTx(delegatedProverUrl, pub, sec): Promise<any> {
+    if (delegatedProverUrl !== undefined) {
+      const url = new URL('/proveTx', delegatedProverUrl);
+      const headers = {'content-type': 'application/json;charset=UTF-8'};
+      return await this.fetchJson(url.toString(), { method: 'POST', headers, body: JSON.stringify({ public: pub, secret: sec }) });
+    } else {
+      return await this.worker.proveTx(pub, sec);
+    }
   }
 
   // ----------------=========< Ephemeral Addresses Pool >=========-----------------

--- a/src/client.ts
+++ b/src/client.ts
@@ -988,8 +988,8 @@ export class ZkBobClient {
     return jobId;
   }
 
-  private async proveTx(tokenAddres: string, pub: any, sec: any): Promise<any> {
-    const token = this.tokens[tokenAddres];
+  private async proveTx(tokenAddress: string, pub: any, sec: any): Promise<any> {
+    const token = this.tokens[tokenAddress];
     if (token.delegatedProverEnabled && token.delegatedProverUrl) {
       console.debug('Delegated Prover: proveTx');
       try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,5 +23,6 @@ export interface Token {
   //  no transactions associated with the account should exist lower that index
   //  set -1 to use the latest index (creating _NEW_ account)
   birthindex: number | undefined;
+  delegatedProverEnabled: boolean;
   delegatedProverUrl: string | undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,12 @@ export interface Token {
   //  no transactions associated with the account should exist lower that index
   //  set -1 to use the latest index (creating _NEW_ account)
   birthindex: number | undefined;
-  delegatedProverEnabled: boolean;
+  proverMode: ProverMode;
   delegatedProverUrl: string | undefined;
+}
+
+export enum ProverMode {
+  Local = "Local",
+  Delegated = "Delegated",
+  DelegatedWithFallback = "DelegatedWithFallback"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,4 +23,5 @@ export interface Token {
   //  no transactions associated with the account should exist lower that index
   //  set -1 to use the latest index (creating _NEW_ account)
   birthindex: number | undefined;
+  delegatedProverUrl: string | undefined;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,9 @@ export class BobError extends Error {
     constructor(message: string) {
         super(message);
         this.name = this.constructor.name;
-        Error.captureStackTrace(this);
+        if (Error.captureStackTrace !== undefined) {
+            Error.captureStackTrace(this);
+        }
     }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -331,8 +331,12 @@ const obj = {
   },
 
   async verifyTxProof(inputs: string[], proof: SnarkProof): Promise<boolean> {
-    return new Promise(async resolve => {
-      resolve(wasm.Proof.verify(transferVk!, inputs, proof));
+    return new Promise(async (resolve, reject) => {
+      try {
+        resolve(wasm.Proof.verify(transferVk!, inputs, proof));
+      } catch (e) {
+        reject(e)
+      }
     });
   },
 


### PR DESCRIPTION
In this PR, the following was done:
1. `proverMode` and `delegatedProverUrl` have been added in `Token`. `proverMode` is enum with possible values: `Local`, `Delegated`, `DelegatedWithFallback`.
2. If `proverMode` is `Delegated` or `DelegatedWithFallback` and delegated prover url is present proofs will be computed on delegated prover.
3. If delegated prover doesn't work or works incorrectly and `proverMode` is `DelegatedWithFallback` local prover will be used. 
4. Added `setProverMode` and `getProverMode` methods to control delegated prover usage. Note: delegated prover can be enabled only if `delegatedProverUrl` was provided.