### PR TITLE
Hotfix for partial tree update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,8 @@ import {
 import { MAX_UINT64 } from '@ethereumjs/util';
 //import { SyncStat, SyncStat } from '.';
 
+const OUTPLUSONE = CONSTANTS.OUT + 1;
+
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_TX_AMOUNT = BigInt(50000000);
 const DEFAULT_TX_FEE = BigInt(100000000);
@@ -228,7 +230,6 @@ export class ZkBobClient {
         // fetch current birthindex right away
         try {
           let curIndex = Number((await client.info(token.relayerUrl)).deltaIndex);
-          const OUTPLUSONE = CONSTANTS.OUT + 1;
           if (curIndex >= (PARTIAL_TREE_USAGE_THRESHOLD * OUTPLUSONE) && curIndex >= OUTPLUSONE) {
             curIndex -= OUTPLUSONE; // we should grab almost one transaction from the regular state
             console.log(`Retrieved account birthindex: ${curIndex}`);
@@ -1384,8 +1385,6 @@ export class ZkBobClient {
   // Wasm package holds only the mined transactions
   // Currently it's just a workaround
   private async updateStateOptimisticWorker(tokenAddress: string): Promise<boolean> {
-    const OUTPLUSONE = CONSTANTS.OUT + 1;
-
     const zpState = this.zpStates[tokenAddress];
     const token = this.tokens[tokenAddress];
 
@@ -1624,8 +1623,6 @@ export class ZkBobClient {
   // Return StateUpdate object
   // This method used for multi-tx
   public async getNewState(tokenAddress: string): Promise<StateUpdate> {
-    const OUTPLUSONE = CONSTANTS.OUT + 1;
-
     const token = this.tokens[tokenAddress];
     const zpState = this.zpStates[tokenAddress];
 
@@ -1686,7 +1683,6 @@ export class ZkBobClient {
   }
 
   public async logStateSync(startIndex: number, endIndex: number, decryptedMemos: DecryptedMemo[]) {
-    const OUTPLUSONE = CONSTANTS.OUT + 1;
     for (const decryptedMemo of decryptedMemos) {
       if (decryptedMemo.index > startIndex) {
         console.info(`📝 Adding hashes to state (from index ${startIndex} to index ${decryptedMemo.index - OUTPLUSONE})`);
@@ -1729,7 +1725,6 @@ export class ZkBobClient {
     const zpState = this.zpStates[tokenAddress];
 
     const coldConfig = zpState.coldStorageConfig;
-    const OUTPLUSONE = CONSTANTS.OUT + 1;
 
     const startRange = fromIndex ?? 0;  // inclusively
     const endRange = toIndex ?? (2 ** CONSTANTS.HEIGHT);  // exclusively

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,7 @@ import {
 import { MAX_UINT64 } from '@ethereumjs/util';
 //import { SyncStat, SyncStat } from '.';
 
-const OUTPLUSONE = CONSTANTS.OUT + 1;
+const OUTPLUSONE = CONSTANTS.OUT + 1; // number of leaves (account + notes) in a transaction
 
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_TX_AMOUNT = BigInt(50000000);
@@ -188,8 +188,6 @@ export interface ClientConfig {
   networkName: string | undefined;
   // An endpoint to interact with the blockchain
   network: NetworkBackend;
-  // Account birthday [moved to Token object]
-  //birthindex: number | undefined;
 }
 
 export class ZkBobClient {

--- a/src/client.ts
+++ b/src/client.ts
@@ -126,15 +126,15 @@ export interface PoolLimits { // all values are in Gwei
     total: bigint;
     components: {
       singleOperation: bigint;
-      daylyForAddress: Limit;
-      daylyForAll: Limit;
+      dailyForAddress: Limit;
+      dailyForAll: Limit;
       poolLimit: Limit;
     };
   }
   withdraw: {
     total: bigint;
     components: {
-      daylyForAll: Limit;
+      dailyForAll: Limit;
     };
   }
   tier: number;
@@ -143,12 +143,12 @@ export interface PoolLimits { // all values are in Gwei
 export interface LimitsFetch { 
   deposit: {
     singleOperation: bigint;
-    daylyForAddress: Limit;
-    daylyForAll: Limit;
+    dailyForAddress: Limit;
+    dailyForAll: Limit;
     poolLimit: Limit;
   }
   withdraw: {
-    daylyForAll: Limit;
+    dailyForAll: Limit;
   }
   tier: number;
 }
@@ -1157,11 +1157,11 @@ export class ZkBobClient {
       return {
         deposit: {
           singleOperation: BigInt(poolLimits.depositCap),
-          daylyForAddress: {
+          dailyForAddress: {
             total: BigInt(poolLimits.dailyUserDepositCap),
             available: BigInt(poolLimits.dailyUserDepositCap) - BigInt(poolLimits.dailyUserDepositCapUsage),
           },
-          daylyForAll: {
+          dailyForAll: {
             total:      BigInt(poolLimits.dailyDepositCap),
             available:  BigInt(poolLimits.dailyDepositCap) - BigInt(poolLimits.dailyDepositCapUsage),
           },
@@ -1171,7 +1171,7 @@ export class ZkBobClient {
           },
         },
         withdraw: {
-          daylyForAll: {
+          dailyForAll: {
             total:      BigInt(poolLimits.dailyWithdrawalCap),
             available:  BigInt(poolLimits.dailyWithdrawalCap) - BigInt(poolLimits.dailyWithdrawalCapUsage),
           },
@@ -1185,11 +1185,11 @@ export class ZkBobClient {
       return {
         deposit: {
           singleOperation: BigInt(10000000000000),  // 10k tokens
-          daylyForAddress: {
+          dailyForAddress: {
             total: BigInt(10000000000000),  // 10k tokens
             available: BigInt(10000000000000),  // 10k tokens
           },
-          daylyForAll: {
+          dailyForAll: {
             total:      BigInt(100000000000000),  // 100k tokens
             available:  BigInt(100000000000000),  // 100k tokens
           },
@@ -1199,7 +1199,7 @@ export class ZkBobClient {
           },
         },
         withdraw: {
-          daylyForAll: {
+          dailyForAll: {
             total:      BigInt(100000000000000),  // 100k tokens
             available:  BigInt(100000000000000),  // 100k tokens
           },
@@ -1242,14 +1242,14 @@ export class ZkBobClient {
     // Calculate deposit limits
     const allDepositLimits = [
       currentLimits.deposit.singleOperation,
-      currentLimits.deposit.daylyForAddress.available,
-      currentLimits.deposit.daylyForAll.available,
+      currentLimits.deposit.dailyForAddress.available,
+      currentLimits.deposit.dailyForAll.available,
       currentLimits.deposit.poolLimit.available,
     ];
     const totalDepositLimit = bigIntMin(...allDepositLimits);
 
     // Calculate withdraw limits
-    const allWithdrawLimits = [ currentLimits.withdraw.daylyForAll.available ];
+    const allWithdrawLimits = [ currentLimits.withdraw.dailyForAll.available ];
     const totalWithdrawLimit = bigIntMin(...allWithdrawLimits);
 
     return {
@@ -1899,13 +1899,13 @@ export class ZkBobClient {
     return {
       deposit: {
         singleOperation: BigInt(res.deposit.singleOperation),
-        daylyForAddress: {
-          total:     BigInt(res.deposit.daylyForAddress.total),
-          available: BigInt(res.deposit.daylyForAddress.available),
+        dailyForAddress: {
+          total:     BigInt(res.deposit.dailyForAddress.total),
+          available: BigInt(res.deposit.dailyForAddress.available),
         },
-        daylyForAll: {
-          total:      BigInt(res.deposit.daylyForAll.total),
-          available:  BigInt(res.deposit.daylyForAll.available),
+        dailyForAll: {
+          total:      BigInt(res.deposit.dailyForAll.total),
+          available:  BigInt(res.deposit.dailyForAll.available),
         },
         poolLimit: {
           total:      BigInt(res.deposit.poolLimit.total),
@@ -1913,9 +1913,9 @@ export class ZkBobClient {
         },
       },
       withdraw: {
-        daylyForAll: {
-          total:      BigInt(res.withdraw.daylyForAll.total),
-          available:  BigInt(res.withdraw.daylyForAll.available),
+        dailyForAll: {
+          total:      BigInt(res.withdraw.dailyForAll.total),
+          available:  BigInt(res.withdraw.dailyForAll.available),
         },
       },
       tier: res.tier === undefined ? 0 : Number(res.tier)

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,4 +19,8 @@ export interface Token {
   poolAddress: string;
   relayerUrl: string;
   coldStorageConfigPath: string;
+  // Account birthday:
+  //  no transactions associated with the account should exist lower that index
+  //  set -1 to use the latest index (creating _NEW_ account)
+  birthindex: number | undefined;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -336,7 +336,7 @@ export function nodeToHex(node: TreeNode): string {
   const writer = new HexStringWriter();
   writer.writeNumber(node.height, 1);
   writer.writeNumber(node.index, 6);
-  writer.writeBigInt(BigInt(node.value), 32, true);
+  writer.writeBigInt(BigInt(node.value), 32);
 
   return writer.toString();
 }
@@ -345,7 +345,7 @@ export function hexToNode(data: string): TreeNode | null {
   const reader = new HexStringReader(data);
   const height = reader.readNumber(1);
   const index = reader.readNumber(6);
-  const value = reader.readBigInt(32, true);
+  const value = reader.readBigInt(32);
 
   if (height != null && index != null && value != null) {
     return { height, index, value: value.toString()};


### PR DESCRIPTION
**Here is hotfixes for the client library for errors discovered during latest testing**
1. Birthindex was moved to the Token object (because it's a shielded token property nor account one): **UI/console changes required**
2. Changing sibling values byte order (LittleEndian -> BigEndian). _This is an urgent issue because currently deployed console isn't working after the latest relayer update._
3. Disabling partial sync in case of error during the first partial tree update
4. Loading actual birthindex during an account initialising (we can loose input notes when fetched actual birthindex during the first state sync)
5. Fixing typo in the PoolLimits structure (dayly -> daily): **UI/console changes required**