### PR TITLE
Feature/check addresses

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { Tokens } from './config';
 import { ethAddrToBuf, toCompactSignature, truncateHexPrefix,
           toTwosComplementHex, addressFromSignature,
-          isRangesIntersected, hexToNode
+          isRangesIntersected, hexToNode, bufToHex, isValidEthAddr, addHexPrefix
         } from './utils';
 import { ZkBobState } from './state';
 import { TxType } from './tx';
@@ -18,10 +18,11 @@ import {
 } from 'libzkbob-rs-wasm-web';
 
 import { 
-  InternalError, NetworkError, PoolJobError, RelayerError, RelayerJobError, TxDepositDeadlineExpiredError,
+  InternalError, NetworkError, PoolJobError, RelayerError, RelayerJobError, SignatureError, TxDepositDeadlineExpiredError,
   TxInsufficientFundsError, TxInvalidArgumentError, TxLimitError, TxProofError, TxSmallAmount
 } from './errors';
 import { MAX_UINT64 } from '@ethereumjs/util';
+import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util';
 //import { SyncStat, SyncStat } from '.';
 
 const OUTPLUSONE = CONSTANTS.OUT + 1; // number of leaves (account + notes) in a transaction
@@ -559,6 +560,19 @@ export class ZkBobClient {
         signature = toCompactSignature(signature);
       }
 
+      // Checking signature correct (and corresponded with declared address)
+      const claimedAddr = `0x${bufToHex(holder)}`;
+      let recoveredAddr;
+      try {
+        const dataToSign: any = await this.createPermittableDepositData(tokenAddress, '1', claimedAddr, token.poolAddress, value, BigInt(deadline), salt);
+        recoveredAddr = recoverTypedSignature({data: dataToSign, signature: `0x${signature}`, version: SignTypedDataVersion.V4});
+      } catch (err) {
+        throw new SignatureError(`Cannot recover address from the provided signature. Error: ${err.message}`);
+      }
+      if (recoveredAddr != claimedAddr) {
+        throw new SignatureError(`The address recovered from the permit signature ${recoveredAddr} doesn't match the declared one ${claimedAddr}`);
+      }
+
       // We should check deadline here because the user could introduce great delay
       if (Math.floor(Date.now() / 1000) > deadline - PERMIT_DEADLINE_THRESHOLD) {
         throw new TxDepositDeadlineExpiredError(deadline);
@@ -572,6 +586,17 @@ export class ZkBobClient {
       const txValid = await this.worker.verifyTxProof(txProof.inputs, txProof.proof);
       if (!txValid) {
         throw new TxProofError();
+      }
+
+      // Checking the depositor's token balance before sending tx
+      let balance;
+      try {
+        balance = (await this.config.network.getTokenBalance(tokenAddress, claimedAddr)) / state.denominator;
+      } catch (err) {
+        throw new InternalError(`Unable to fetch depositor's balance. Error: ${err.message}`);
+      }
+      if (balance < amountGwei) {
+        throw new TxInsufficientFundsError(amountGwei, balance);
       }
 
       const tx = { txType: TxType.BridgeDeposit, memo: txData.memo, proof: txProof, depositSignature: signature };
@@ -748,6 +773,12 @@ export class ZkBobClient {
     const token = this.tokens[tokenAddress];
     const state = this.zpStates[tokenAddress];
 
+    // validate withdrawal address
+    if (isValidEthAddr(address) == false || address == NULL_ADDRESS) {
+      throw new TxInvalidArgumentError('Please provide a valid non-zero address');
+    }
+    const addressBin = ethAddrToBuf(address);
+
     if (amountGwei < MIN_TX_AMOUNT) {
       throw new TxSmallAmount(amountGwei, MIN_TX_AMOUNT);
     }
@@ -764,8 +795,6 @@ export class ZkBobClient {
       const feeEst = await this.feeEstimate(tokenAddress, [amountGwei], TxType.Withdraw, false);
       throw new TxInsufficientFundsError(amountGwei + feeEst.total, available);
     }
-
-    const addressBin = ethAddrToBuf(address);
 
     var jobsIds: string[] = [];
     var optimisticState: StateUpdate = {
@@ -881,6 +910,18 @@ export class ZkBobClient {
     if (this.config.network.isSignatureCompact()) {
       fullSignature = toCompactSignature(fullSignature);
     }
+
+    // Checking the depositor's token balance before sending tx
+    let balance;
+    try {
+      balance = (await this.config.network.getTokenBalance(tokenAddress, addrFromSig)) / state.denominator;
+    } catch (err) {
+      throw new InternalError(`Unable to fetch depositor's balance. Error: ${err.message}`);
+    }
+    if (balance < amountGwei) {
+      throw new TxInsufficientFundsError(amountGwei, balance);
+    }
+
 
     const tx = { txType: TxType.Deposit, memo: txData.memo, proof: txProof, depositSignature: fullSignature };
     const jobId = await this.sendTransactions(token.relayerUrl, [tx]);

--- a/src/client.ts
+++ b/src/client.ts
@@ -595,7 +595,7 @@ export class ZkBobClient {
       } catch (err) {
         throw new InternalError(`Unable to fetch depositor's balance. Error: ${err.message}`);
       }
-      if (balance < amountGwei) {
+      if (balance < (amountGwei + feeGwei)) {
         throw new TxInsufficientFundsError(amountGwei, balance);
       }
 
@@ -918,7 +918,7 @@ export class ZkBobClient {
     } catch (err) {
       throw new InternalError(`Unable to fetch depositor's balance. Error: ${err.message}`);
     }
-    if (balance < amountGwei) {
+    if (balance < (amountGwei + feeGwei)) {
       throw new TxInsufficientFundsError(amountGwei, balance);
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,6 +46,12 @@ export class TxInvalidArgumentError extends BobError {
     }
 }
 
+export class SignatureError extends BobError {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
 export class TxDepositDeadlineExpiredError extends BobError {
     public deadline: number;
     constructor(deadline: number) {

--- a/src/networks/evm.ts
+++ b/src/networks/evm.ts
@@ -114,7 +114,6 @@ export class EvmNetwork implements NetworkBackend {
         ];
         this.contract = new this.web3.eth.Contract(abi) as unknown as Contract;
 
-        // just the Transfer() event definition is sufficient in this case
         const abiTokenJson: AbiItem[] = [{
                 anonymous: false,
                 inputs: [{
@@ -156,6 +155,20 @@ export class EvmNetwork implements NetworkBackend {
                 }],
                 stateMutability: 'view',
                 type: 'function'
+            }, {
+                constant: true,
+                inputs: [{
+                    name: '_owner',
+                    type: 'address'
+                }],
+                name: 'balanceOf',
+                outputs: [{
+                    name: 'balance',
+                    type: 'uint256'
+                }],
+                payable: false,
+                stateMutability: 'view',
+                type: 'function'
             }];
         this.token = new this.web3.eth.Contract(abiTokenJson) as unknown as Contract;
     }
@@ -168,9 +181,15 @@ export class EvmNetwork implements NetworkBackend {
         this.token.options.address = tokenAddress;
         return await this.token.methods.name().call();
     }
+    
     public async getTokenNonce(tokenAddress: string, address: string): Promise<number> {
         this.token.options.address = tokenAddress;
         return Number(await this.token.methods.nonces(address).call());
+    }
+
+    public async getTokenBalance(tokenAddress: string, address: string): Promise<bigint> {    // in wei
+        this.token.options.address = tokenAddress;
+        return BigInt(await this.token.methods.balanceOf(address).call());
     }
 
     public async getDenominator(contractAddress: string): Promise<bigint> {

--- a/src/networks/network.ts
+++ b/src/networks/network.ts
@@ -2,6 +2,7 @@ export interface NetworkBackend {
     getChainId(): Promise<number>;
     getTokenName(tokenAddress: string): Promise<string>;
     getTokenNonce(tokenAddress: string, address: string): Promise<number>;
+    getTokenBalance(tokenAddress: string, address: string): Promise<bigint>;
     getDenominator(contractAddress: string): Promise<bigint>;
     poolLimits(contractAddress: string, address: string | undefined): Promise<any>;
     poolState(contractAddress: string, index?: bigint): Promise<{index: bigint, root: bigint}>;

--- a/src/networks/polkadot.ts
+++ b/src/networks/polkadot.ts
@@ -13,6 +13,10 @@ export class PolkadotNetwork implements NetworkBackend {
         return 0;
     }
 
+    async getTokenBalance(tokenAddress: string, address: string): Promise<bigint> {
+        return BigInt(0);
+    }
+
     async getDenominator(contractAddress: string): Promise<bigint> {
         return BigInt(1000); // FIXME
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,6 +92,10 @@ export function addHexPrefix(data: string): string {
   return data;
 }
 
+export function isValidEthAddr(address: string): boolean {
+  return address.match('^0x[a-fA-F0-9]{40}$') ? true : false;
+}
+
 export function ethAddrToBuf(address: string): Uint8Array {
   return hexToBuf(address, 20);
 }
@@ -272,12 +276,12 @@ export function toCompactSignature(signature: string): string {
     if (v == "1c") {
       return `${signature.slice(0, 64)}${(parseInt(signature[64], 16) | 8).toString(16)}${signature.slice(65, 128)}`;
     } else if (v != "1b") {
-      throw ("invalid signature: v should be 27 or 28");
+      throw new InternalError("invalid signature: v should be 27 or 28");
     }
 
     return signature.slice(0, 128);
   } else if (signature.length < 128) {
-    throw ("invalid signature: it should consist at least 64 bytes (128 chars)");
+    throw new InternalError("invalid signature: it should consist at least 64 bytes (128 chars)");
   }
 
   // it seems the signature already compact

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,10 +92,6 @@ export function addHexPrefix(data: string): string {
   return data;
 }
 
-export function isValidEthAddr(address: string): boolean {
-  return address.match('^0x[a-fA-F0-9]{40}$') ? true : false;
-}
-
 export function ethAddrToBuf(address: string): Uint8Array {
   return hexToBuf(address, 20);
 }


### PR DESCRIPTION
**Added additional validations before transaction sendeng:**
- depositor's address balance before sending tx should be enoung
- recovered and declared addresses during permit deposit should be the same
- withdrawal address should be correct and non-zero