### PR TITLE
Loading params in background

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -433,7 +433,7 @@ export class ZkBobClient {
     return txHash;
   }
 
-  public async setProverMode(tokenAddress: string, mode: ProverMode) {
+  public setProverMode(tokenAddress: string, mode: ProverMode) {
     if (!Object.values(ProverMode).includes(mode)) {
       throw new InternalError("Provided mode isn't correct. Possible modes: Local, Delegated, and DelegatedWithFallback");
     }
@@ -444,7 +444,7 @@ export class ZkBobClient {
       throw new InternalError(`Delegated prover can't be enabled because delegated prover url wasn't provided`)
     }
 
-    if (mode != ProverMode.Delegated && await this.worker.txParamsNeedToLoad()) {
+    if (mode != ProverMode.Delegated) {
       this.worker.loadTxParams();
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -274,10 +274,7 @@ export class ZkBobClient {
       }
 
       try {
-        client.setProverMode(address, token.proverMode);
-        if (client.getProverMode(address) != ProverMode.Delegated) {
-          client.worker.loadTxParams();
-        }
+        await client.setProverMode(address, token.proverMode);
       } catch (err) {
         console.error(err);
       }
@@ -436,7 +433,7 @@ export class ZkBobClient {
     return txHash;
   }
 
-  public setProverMode(tokenAddress: string, mode: ProverMode) {
+  public async setProverMode(tokenAddress: string, mode: ProverMode) {
     if (!Object.values(ProverMode).includes(mode)) {
       throw new InternalError("Provided mode isn't correct. Possible modes: Local, Delegated, and DelegatedWithFallback");
     }
@@ -446,6 +443,11 @@ export class ZkBobClient {
       token.proverMode = ProverMode.Local;
       throw new InternalError(`Delegated prover can't be enabled because delegated prover url wasn't provided`)
     }
+
+    if (mode != ProverMode.Delegated && await this.worker.txParamsNeedToLoad()) {
+      this.worker.loadTxParams();
+    }
+
     token.proverMode = mode;
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -275,6 +275,9 @@ export class ZkBobClient {
 
       try {
         client.setProverMode(address, token.proverMode);
+        if (client.getProverMode(address) != ProverMode.Delegated) {
+          client.worker.loadTxParams();
+        }
       } catch (err) {
         console.error(err);
       }

--- a/src/file-cache.ts
+++ b/src/file-cache.ts
@@ -44,7 +44,7 @@ export class FileCache {
   public async cache(path: string, loadingCallback: LoadingProgressCallback | undefined = undefined): Promise<ArrayBuffer> {
     const response = await fetch(path);
 
-    if (response.body) {
+    if (response.status == 200 && response.body) {
       const reader = response.body.getReader();  
       
       // Total file length

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export enum InitState {
 
 export interface InitStatus {
   state: InitState;
-  download: {loaded: number, total: number};  // bytes
   error?: Error | undefined;
 }
 
@@ -43,10 +42,8 @@ export async function init(
 ): Promise<ZkBobLibState> {
   const fileCache = await FileCache.init();
 
-  let lastProgress = {loaded: -1, total: -1};
-
   if (statusCallback !== undefined) {
-    statusCallback({ state: InitState.Started, download: lastProgress });
+    statusCallback({ state: InitState.Started });
   }
 
   // Get tx parameters hash from the relayer
@@ -65,7 +62,7 @@ export async function init(
   // Intercept all possible exceptions to process `Failed` status
   try {
     if (statusCallback !== undefined) {
-      statusCallback({ state: InitState.InitWorker, download: lastProgress });
+      statusCallback({ state: InitState.InitWorker });
     }
 
     worker = wrap(new Worker(new URL('./worker.js', import.meta.url), { type: 'module' }));
@@ -79,12 +76,12 @@ export async function init(
     });
 
     if (statusCallback !== undefined) {
-      statusCallback({ state: InitState.Completed, download: lastProgress });
+      statusCallback({ state: InitState.Completed });
     }
   } catch(err) {
     console.error(`Cannot initialize client library: ${err.message}`);
     if (statusCallback !== undefined) {
-      statusCallback({ state: InitState.Failed, download: lastProgress, error: err });
+      statusCallback({ state: InitState.Failed, error: err });
     }
   }
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,0 +1,98 @@
+import { InternalError } from "./errors";
+import { FileCache } from "./file-cache";
+
+export enum LoadingStatus {
+    NotStarted = 0,
+    InProgress,
+    Completed,
+    Failed
+}
+
+export class SnarkParams {
+    url: string;
+    expectedHash: string | undefined;
+    params: any | undefined;
+    loadingPromise: Promise<any>;
+    loadingStatus: LoadingStatus;
+
+    public constructor(url: string, expectedHash: string | undefined) {
+        this.loadingStatus = LoadingStatus.NotStarted;
+        this.url = url;
+        this.expectedHash = expectedHash;
+    }
+
+    public async get(wasm: any): Promise<any> {
+        if (this.loadingStatus == LoadingStatus.Completed) {
+            return this.params;
+        }
+
+        if (this.loadingStatus == LoadingStatus.NotStarted || this.loadingStatus == LoadingStatus.Failed) {
+            this.load(wasm);
+        }
+
+        return await this.loadingPromise;
+    }
+
+    public load(wasm: any) {
+        this.loadingStatus = LoadingStatus.InProgress;
+        this.loadingPromise = new Promise(async (resolve, reject) => {
+            try {
+                const cache = await FileCache.init();
+
+                console.time(`Load parameters from DB`);
+                let txParamsData = await cache.get(this.url)
+                    .finally(() => console.timeEnd(`Load parameters from DB`));
+
+                // check parameters hash if needed
+                if (txParamsData && this.expectedHash !== undefined) {
+                    let computedHash = await cache.getHash(this.url);
+                    if (!computedHash) {
+                        computedHash = await cache.saveHash(this.url, txParamsData);
+                    }
+
+                    if (computedHash.toLowerCase() != this.expectedHash.toLowerCase()) {
+                        // forget saved params in case of hash inconsistence
+                        console.warn(`Hash of cached tx params (${computedHash}) doesn't associated with provided (${this.url}).`);
+                        cache.remove(this.url);
+                        txParamsData = null;
+                    }
+                }
+
+                let params;
+                if (!txParamsData) {
+                    console.time(`Download params`);
+                    txParamsData = await cache.cache(this.url)
+                        .finally(() => console.timeEnd(`Download params`));
+
+                    try {
+                        console.time(`Creating Params object`);
+                        params = wasm.Params.fromBinary(new Uint8Array(txParamsData!));
+                    } finally {
+                        console.timeEnd(`Creating Params object`);
+                    }
+                } else {
+                    console.log(`File ${this.url} is present in cache, no need to fetch`);
+
+                    try {
+                        console.time(`Creating Params object`);
+                        params = wasm.Params.fromBinaryExtended(new Uint8Array(txParamsData!), false, false);
+                    } finally {
+                        console.timeEnd(`Creating Params object`);
+                    }
+                }
+                resolve(params);
+            } catch (err) {
+                reject(new InternalError(`Failed to load params: ${err.message}`));
+            }
+        }).then((params) => {
+            this.params = params;
+            this.loadingStatus = LoadingStatus.Completed;
+            return params;
+        }, (err) => {
+            this.params = undefined;
+            this.loadingStatus = LoadingStatus.Failed;
+            throw err;
+        })
+    }
+}
+

--- a/src/params.ts
+++ b/src/params.ts
@@ -22,23 +22,16 @@ export class SnarkParams {
     }
 
     public async get(wasm: any): Promise<any> {
-        if (this.loadingStatus == LoadingStatus.Completed) {
+        if (this.isParamsReady()) {
             return this.params;
         }
-
-        if (this.needToLoad()) {
-            this.load(wasm);
-        }
-
+        
+        this.load(wasm);
         return await this.loadingPromise;
     }
 
-    public needToLoad(): boolean {
-        return this.loadingStatus == LoadingStatus.NotStarted || this.loadingStatus == LoadingStatus.Failed;
-    }
-
     public load(wasm: any) {
-        if (this.loadingStatus == LoadingStatus.InProgress) {
+        if (this.isParamsReady() || this.loadingStatus == LoadingStatus.InProgress) {
             return;
         }
 
@@ -101,6 +94,10 @@ export class SnarkParams {
             this.loadingStatus = LoadingStatus.Failed;
             throw err;
         })
+    }
+
+    private isParamsReady(): boolean {
+        return this.params !== undefined;
     }
 }
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -9,11 +9,11 @@ export enum LoadingStatus {
 }
 
 export class SnarkParams {
-    url: string;
-    expectedHash: string | undefined;
-    params: any | undefined;
-    loadingPromise: Promise<any> | undefined;
-    loadingStatus: LoadingStatus;
+    private url: string;
+    private expectedHash: string | undefined;
+    private params: any | undefined;
+    private loadingPromise: Promise<any> | undefined;
+    private loadingStatus: LoadingStatus;
 
     public constructor(url: string, expectedHash: string | undefined) {
         this.loadingStatus = LoadingStatus.NotStarted;

--- a/src/params.ts
+++ b/src/params.ts
@@ -95,12 +95,10 @@ export class SnarkParams {
         }).then((params) => {
             this.params = params;
             this.loadingStatus = LoadingStatus.Completed;
-            this.loadingPromise = undefined;
             return params;
         }, (err) => {
             this.params = undefined;
             this.loadingStatus = LoadingStatus.Failed;
-            this.loadingPromise = undefined;
             throw err;
         })
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -60,8 +60,8 @@ const obj = {
         const cache = await FileCache.init();
 
         console.time(`Load parameters from DB`);
-        let txParamsData = await cache.get(transferParamsUrl);
-        console.timeEnd(`Load parameters from DB`);
+        let txParamsData = await cache.get(transferParamsUrl)
+          .finally(() => console.timeEnd(`Load parameters from DB`));
 
         // check parameters hash if needed
         if (txParamsData && transferParamsHash !== undefined) {
@@ -81,22 +81,27 @@ const obj = {
         let txParams;
         if (!txParamsData) {
           console.time(`Download params`);
-          txParamsData = await cache.cache(transferParamsUrl);
-          console.timeEnd(`Download params`);
+          txParamsData = await cache.cache(transferParamsUrl)
+            .finally(() => console.timeEnd(`Download params`));
 
-          console.time(`Creating Params object`);
-          txParams = wasm.Params.fromBinary(new Uint8Array(txParamsData!));
-          console.timeEnd(`Creating Params object`);
-
+          try {
+            console.time(`Creating Params object`);
+            txParams = wasm.Params.fromBinary(new Uint8Array(txParamsData!));
+          } finally {
+            console.timeEnd(`Creating Params object`);
+          }
         } else {
           console.log(`File ${transferParamsUrl} is present in cache, no need to fetch`);
-          console.time(`Creating Params object`);
-          txParams = wasm.Params.fromBinaryExtended(new Uint8Array(txParamsData!), false, false);
-          console.timeEnd(`Creating Params object`);
+          
+          try {
+            console.time(`Creating Params object`);
+            txParams = wasm.Params.fromBinaryExtended(new Uint8Array(txParamsData!), false, false);
+          } finally {
+            console.timeEnd(`Creating Params object`);
+          }
         }
         resolve(txParams);
       } catch (err) {
-        console.warn(`Failed to load params: ${err.message}`);
         reject(new Error(`Failed to load params: ${err.message}`));
       }
     });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -106,7 +106,8 @@ const obj = {
     console.debug('Web worker: proveTx');
     let params = await transferParams.catch((_) => {
       console.info("Trying to load params again...");
-      return this.getTxParams();
+      transferParams = this.getTxParams();
+      return transferParams;
     });
     return wasm.Proof.tx(params, pub, sec);
   },
@@ -117,216 +118,133 @@ const obj = {
   },
 
   async parseTxs(sk: Uint8Array, txs: IndexedTx[]): Promise<ParseTxsResult> {
-    return new Promise(async resolve => {
-      console.debug('Web worker: parseTxs');
-      const result = txParser.parseTxs(sk, txs)
-      sk.fill(0)
-      resolve(result);
-    });
+    console.debug('Web worker: parseTxs');
+    const result = txParser.parseTxs(sk, txs)
+    sk.fill(0)
+    return result;
   },
 
   async createAccount(address: string, sk: Uint8Array, networkName: string, userId: string): Promise<void> {
-    return new Promise(async resolve => {
-      console.debug('Web worker: createAccount');
-      try {
-        const state = await wasm.UserState.init(`zp.${networkName}.${userId}`);
-        const acc = new wasm.UserAccount(sk, state);
-        zpAccounts[address] = acc;
-      } catch (e) {
-        console.error(e);
-      }
-      resolve();
-    });
+    console.debug('Web worker: createAccount');
+    try {
+      const state = await wasm.UserState.init(`zp.${networkName}.${userId}`);
+      const acc = new wasm.UserAccount(sk, state);
+      zpAccounts[address] = acc;
+    } catch (e) {
+      console.error(e);
+    }
   },
 
   async totalBalance(address: string): Promise<string> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].totalBalance());
-    });
+    return zpAccounts[address].totalBalance();
   },
 
   async accountBalance(address: string): Promise<string> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].accountBalance());
-    });
+    return zpAccounts[address].accountBalance();
   },
 
   async noteBalance(address: string): Promise<string> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].noteBalance());
-    });
+    return zpAccounts[address].noteBalance();
   },
 
   async usableNotes(address: string): Promise<any[]> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].getUsableNotes());
-    });
+    return zpAccounts[address].getUsableNotes();
   },
 
   async isOwnAddress(address: string, shieldedAddress: string): Promise<boolean> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].isOwnAddress(shieldedAddress));
-    });
+    return zpAccounts[address].isOwnAddress(shieldedAddress);
   },
 
   async rawState(address: string): Promise<any> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].getWholeState());
-    });
+    return zpAccounts[address].getWholeState();
   },
 
   async free(address: string): Promise<void> {
-    return new Promise(async resolve => {
-      zpAccounts[address].free();
-      resolve();
-    });
+    return zpAccounts[address].free();
   },
 
   async generateAddress(address: string): Promise<string> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].generateAddress());
-    });
+    return zpAccounts[address].generateAddress();
   },
 
   async createDepositPermittable(address: string, deposit: IDepositPermittableData): Promise<any> {
-    return await zpAccounts[address].createDepositPermittable(deposit);
+    return zpAccounts[address].createDepositPermittable(deposit);
   },
 
   async createTransferOptimistic(address: string, tx: ITransferData, optimisticState: any): Promise<any> {
-    return await zpAccounts[address].createTransferOptimistic(tx, optimisticState);
+    return zpAccounts[address].createTransferOptimistic(tx, optimisticState);
   },
 
   async createWithdrawalOptimistic(address: string, tx: IWithdrawData, optimisticState: any): Promise<any> {
-    return await zpAccounts[address].createWithdrawalOptimistic(tx, optimisticState);
+    return zpAccounts[address].createWithdrawalOptimistic(tx, optimisticState);
   },
 
   async createDeposit(address: string, deposit: IDepositData): Promise<any> {
-    return await zpAccounts[address].createDeposit(deposit);
+    return zpAccounts[address].createDeposit(deposit);
   },
 
   async createTransfer(address: string, transfer: ITransferData): Promise<any> {
-    return await zpAccounts[address].createTransfer(transfer);
+    return zpAccounts[address].createTransfer(transfer);
   },
 
   async nextTreeIndex(address: string): Promise<bigint> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].nextTreeIndex());
-    });
+    return zpAccounts[address].nextTreeIndex();
   },
 
   async firstTreeIndex(address: string): Promise<bigint | undefined> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].firstTreeIndex());
-    });
+    return zpAccounts[address].firstTreeIndex();
   },
 
   async getRoot(address: string): Promise<string> {
-    return new Promise(async resolve => {
-      resolve(zpAccounts[address].getRoot());
-    });
+    return zpAccounts[address].getRoot();
   },
 
   async getRootAt(address: string, index: bigint): Promise<string> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        resolve(zpAccounts[address].getRootAt(index));
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return zpAccounts[address].getRootAt(index);
   },
 
   async getLeftSiblings(address: string, index: bigint): Promise<TreeNode[]> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        resolve(zpAccounts[address].getLeftSiblings(index));
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return zpAccounts[address].getLeftSiblings(index);
   },
 
   async rollbackState(address: string, index: bigint): Promise<bigint> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        resolve(zpAccounts[address].rollbackState(index));
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return zpAccounts[address].rollbackState(index);
   },
 
   async wipeState(address: string): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        resolve(zpAccounts[address].wipeState());
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return zpAccounts[address].wipeState();
   },
 
   async getTreeLastStableIndex(address: string): Promise<bigint> {
-    return new Promise(async (resolve) => {
-      resolve(zpAccounts[address].treeGetStableIndex());
-    });
+    return zpAccounts[address].treeGetStableIndex();
   },
 
   async setTreeLastStableIndex(address: string, index: bigint): Promise<void> {
-    return new Promise(async (resolve) => {
-      resolve(zpAccounts[address].treeSetStableIndex(index));
-    });
+    return zpAccounts[address].treeSetStableIndex(index);
   },
 
   async updateState(address: string, stateUpdate: StateUpdate, siblings?: TreeNode[]): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        let result = zpAccounts[address].updateState(stateUpdate, siblings);
-        resolve(result)
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return zpAccounts[address].updateState(stateUpdate, siblings);
   },
 
   async updateStateColdStorage(address: string, bulks: Uint8Array[], indexFrom?: bigint, indexTo?: bigint): Promise<ParseTxsColdStorageResult> {
-    return new Promise(async (resolve, reject) => {
-      console.debug('Web worker: updateStateColdStorage');
-      try {
-        let result = zpAccounts[address].updateStateColdStorage(bulks, indexFrom, indexTo);
-        resolve(result);
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return zpAccounts[address].updateStateColdStorage(bulks, indexFrom, indexTo);
   },
 
   async verifyTxProof(inputs: string[], proof: SnarkProof): Promise<boolean> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        resolve(wasm.Proof.verify(transferVk!, inputs, proof));
-      } catch (e) {
-        reject(e)
-      }
-    });
+    return wasm.Proof.verify(transferVk!, inputs, proof);
   },
 
   async verifyTreeProof(inputs: string[], proof: SnarkProof): Promise<boolean> {
-    return new Promise(async resolve => {
-      resolve(wasm.Proof.verify(treeVk!, inputs, proof));
-    });
+    return wasm.Proof.verify(treeVk!, inputs, proof);
   },
 
   async verifyShieldedAddress(shieldedAddress: string): Promise<boolean> {
-    return new Promise(async resolve => {
-      resolve(wasm.validateAddress(shieldedAddress));
-    });
+    return wasm.validateAddress(shieldedAddress);
   },
 
   async assembleAddress(d: string, p_d: string): Promise<string> {
-    return new Promise(async resolve => {
-      resolve(wasm.assembleAddress(d, p_d));
-    });
+    return wasm.assembleAddress(d, p_d);
   }
 };
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,6 @@
 import { expose } from 'comlink';
 import { IndexedTx, ParseTxsResult, ParseTxsColdStorageResult, StateUpdate, SnarkProof, TreeNode,
-          ITransferData, IDepositData, IWithdrawData, IDepositPermittableData, Params
+          ITransferData, IDepositData, IWithdrawData, IDepositPermittableData
         } from 'libzkbob-rs-wasm-web';
 import { threads } from 'wasm-feature-detect';
 import { SnarkParams } from './params';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -48,8 +48,12 @@ const obj = {
     console.info('Web worker init complete.');
   },
 
-  loadTxParams() {
+  async loadTxParams() {
     txParams.load(wasm);
+  },
+
+  async txParamsNeedToLoad(): Promise<boolean> {
+    return txParams.needToLoad();
   },
 
   async proveTx(pub, sec) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,10 +52,6 @@ const obj = {
     txParams.load(wasm);
   },
 
-  async txParamsNeedToLoad(): Promise<boolean> {
-    return txParams.needToLoad();
-  },
-
   async proveTx(pub, sec) {
     console.debug('Web worker: proveTx');
     let params = await txParams.get(wasm);


### PR DESCRIPTION
In this PR, the following was done:
1. Loading params process runs asynchronously now if the prover mode is `Local` or `DelegatedWithFallback`. If the prover mode is `Delegated` params don't load at all.
2. If the params loading promise was rejected or not started we try to load params again in `worker.proveTx`.
3. The most of loading stages are executed in the background now so I've removed related code from `worker.js`.
4. I've also removed `DownloadingParams` and `InitWasm` from `InitState` enum. **The code that handles these states in `zkbob-console` and `zkbob-ui` is not necessary anymore.**
5. I've checked that this [suggestion](https://github.com/zkBob/zkbob-client-js/pull/72#discussion_r1060355547) is correct so I've refactored code in `worker.js` accordingly.

I am not sure if it is necessary to add downloading params state when a user tries to prove tx. In most cases, params will be ready or almost ready when user will calculate proof for the first tx. Wdyt?