### PR TITLE
Returning relayer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { wrap } from 'comlink';
 import { SnarkConfigParams } from './config';
 import { FileCache } from './file-cache';
 export { TreeNode } from 'libzkbob-rs-wasm-web';
-export { ZkBobClient, TransferConfig, FeeAmount, PoolLimits, TreeState, SyncStat } from './client';
+export { ZkBobClient, TransferConfig, FeeAmount, PoolLimits, TreeState, SyncStat, RelayerVersion } from './client';
 export { TxType } from './tx';
 export { HistoryRecord, HistoryTransactionType, HistoryRecordState } from './history'
 export { EphemeralAddress, EphemeralPool } from './ephemeral'


### PR DESCRIPTION
The new function `getRelayerVersion` has been added. It's return `RelayerVersion` object:

```
export interface RelayerVersion {
  ref: string;
  commitHash: string;
}
```

The function loads the relayer version just once for the first request. It will return the cached value for the next requests. So the app can invoke this method as many times as needed.

The function can throw an error in case of relayer or network error (e.g. when the response format does not match the `RelayerVersion` interface). So it's need to cover it into try-catch block