### PR TITLE
Overriding multithreading auto-selection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export async function init(
   snarkParams: SnarkConfigParams,
   relayerURL: string | undefined = undefined, // we'll try to fetch parameters hash for verification
   statusCallback: InitLibCallback | undefined = undefined,
+  forcedMultithreading: boolean | undefined = undefined, // specify this parameter to override multithreading autoselection
 ): Promise<ZkBobLibState> {
   const fileCache = await FileCache.init();
 
@@ -76,7 +77,8 @@ export async function init(
     {
       transferVkUrl: snarkParams.transferVkUrl,
       treeVkUrl: snarkParams.treeVkUrl,
-    });
+    },
+    forcedMultithreading);
 
     
     initializer.then(() => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,13 +35,15 @@ const obj = {
     paramUrls: { txParams: string; treeParams: string },
     txParamsHash: string | undefined = undefined,  // skip hash checking when undefined
     vkUrls: {transferVkUrl: string, treeVkUrl: string},
+    forcedMultithreading: boolean | undefined = undefined,
   ) {
     loadingStage = LoadingStage.Init;
     console.info('Initializing web worker...');
     
     // Safari doesn't support spawning Workers from inside other Workers yet.
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    const isMt = await threads() && !isSafari;
+    const isMtSupported = await threads() && !isSafari;
+    const isMt = forcedMultithreading ?? isMtSupported;  // forced MT param has a higher priority than supported one
     
     if (isMt) {
       console.log('Using multi-threaded version');


### PR DESCRIPTION
With that changes the application can override the multi\single-threading worker selection during the initialisation phase (`init` function).
To override MT selection app should specify `forcedMultithreading` parameter. If it is omit or `undefined` the standard selection scheme will be used.
Please keep in mind if that parameter specified, the are no additional checks performed (i.e. when you set `forcedMultithreading` to `true` on the unsupported target the multithreading worker will be initialised whatever)