### PR TITLE
Fetch prover version, prover health check

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,5 @@
+import { ServiceType } from "./client";
+
 export class BobError extends Error {
     constructor(message: string) {
         super(message);
@@ -72,29 +74,12 @@ export class TxInsufficientFundsError extends BobError {
     }
 }
 
-export class RelayerError extends BobError {
-    public code: number;
-    constructor(code: number, message: string) {
-        super(`Relayer response incorrect (code ${code}): ${message}`);
-        this.code = code;
-    }
-}
-
-export class DelegatedProverError extends BobError {
-    public code: number;
-    constructor(code: number, message: string) {
-        super(`Delegated prover response incorrect (code ${code}): ${message}`);
-        this.code = code;
-    }
-}
-
 export class ServiceError extends BobError {
     public code: number;
-    public message: string;
-    constructor(code: number, message: string) {
-        super(`Service response incorrect (code ${code}): ${message}`);
+    public service: ServiceType;
+    constructor(service: ServiceType, code: number, message: string) {
+        super(`${service} response incorrect (code ${code}): ${message}`);
         this.code = code;
-        this.message = message
     }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -80,6 +80,24 @@ export class RelayerError extends BobError {
     }
 }
 
+export class DelegatedProverError extends BobError {
+    public code: number;
+    constructor(code: number, message: string) {
+        super(`Delegated prover response incorrect (code ${code}): ${message}`);
+        this.code = code;
+    }
+}
+
+export class ServiceError extends BobError {
+    public code: number;
+    public message: string;
+    constructor(code: number, message: string) {
+        super(`Service response incorrect (code ${code}): ${message}`);
+        this.code = code;
+        this.message = message
+    }
+}
+
 export class NetworkError extends BobError {
     constructor(cause?: Error, host?: string) {
         super(`Unable connect to the host ${host !== undefined ? host : ''} (${cause?.message})`);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -80,6 +80,7 @@ export class ServiceError extends BobError {
     constructor(service: ServiceType, code: number, message: string) {
         super(`${service} response incorrect (code ${code}): ${message}`);
         this.code = code;
+        this.service = service;
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { wrap } from 'comlink';
 import { SnarkConfigParams } from './config';
 import { FileCache } from './file-cache';
 export { TreeNode } from 'libzkbob-rs-wasm-web';
-export { ZkBobClient, TransferConfig, FeeAmount, PoolLimits, TreeState, SyncStat, RelayerVersion } from './client';
+export { ZkBobClient, TransferConfig, FeeAmount, PoolLimits, TreeState, SyncStat, ServiceVersion } from './client';
 export { TxType } from './tx';
 export { HistoryRecord, HistoryTransactionType, HistoryRecordState } from './history'
 export { EphemeralAddress, EphemeralPool } from './ephemeral'


### PR DESCRIPTION
In this PR the following was done:
1. Added methods `fetchProverVersion` and `getProverVesrion` that fetch and get the delegated prover version accordingly.
2. Added the delegated prover version fetch in setProverMode to check the health of the delegated prover service before using.
3. Replaced `RelayerError` with `ServiceError` in `fetchJson` and created separate methods `fetchJsonFromRelayer` and `fetchJsonFromProver` with correct errors.