### PR TITLE
Rework multitransfer note aggregation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1163,7 +1163,7 @@ export class ZkBobClient {
         break;
       }
 
-      accountBalance += BigInt(inNotesBalance) - BigInt(txFee);
+      accountBalance += inNotesBalance - txFee;
       if (accountBalance > maxAmount) {
         maxAmount = accountBalance;
       }
@@ -1235,12 +1235,7 @@ export class ZkBobClient {
       }
     }
 
-    if (!allowPartial) {
-      parts = [];
-    }
-
-    console.log(parts);
-    return parts;
+    return allowPartial ? parts : [];
   }
 
   // calculate summ of notes grouped by CONSTANTS::IN

--- a/src/client.ts
+++ b/src/client.ts
@@ -896,12 +896,11 @@ export class ZkBobClient {
       jobsIds.push(jobId);
 
       // Temporary save transaction part in the history module (to prevent history delays)
+      const ts = Math.floor(Date.now() / 1000);
       if (txType == TxType.Transfer) {
-        const ts = Math.floor(Date.now() / 1000);
         const record = await HistoryRecord.transferOut([], onePart.fee, ts, '0', true, (addr) => this.isMyAddress(tokenAddress, addr));
         state.history.keepQueuedTransactions([record], jobId);
       } else {
-        const ts = Math.floor(Date.now() / 1000);
         const record = await HistoryRecord.withdraw(address, onePart.outNotes[0].amountGwei, onePart.fee, ts, '0', true);
         state.history.keepQueuedTransactions([record], jobId);
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -904,7 +904,7 @@ export class ZkBobClient {
       // Temporary save transaction part in the history module (to prevent history delays)
       const ts = Math.floor(Date.now() / 1000);
       if (txType == TxType.Transfer) {
-        const record = await HistoryRecord.transferOut([], onePart.fee, ts, '0', true, (addr) => this.isMyAddress(tokenAddress, addr));
+        const record = await HistoryRecord.transferOut([], onePart.fee, ts, '0', true, async () => false);
         state.history.keepQueuedTransactions([record], jobId);
       } else {
         const record = await HistoryRecord.withdraw(address, onePart.outNotes[0].amountGwei, onePart.fee, ts, '0', true);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1199,8 +1199,8 @@ export class ZkBobClient {
 
     let aggregatedTransfers: MultinoteTransferRequest[] = [];
     for (let i = 0; i < transfers.length; i += CONSTANTS.OUT) {
-      let requests = transfers.slice(i, i + CONSTANTS.OUT);
-      let totalAmount = requests.reduce(
+      const requests = transfers.slice(i, i + CONSTANTS.OUT);
+      const totalAmount = requests.reduce(
         (acc, cur) => acc + cur.amountGwei,
         BigInt(0)
       );
@@ -1215,7 +1215,7 @@ export class ZkBobClient {
     
     let i = 0;
     do {
-      txParts = this.getTransferConfigs(accountBalance, feeGwei, groupedNotesBalances.slice(i, i + aggregatedTransfers.length), aggregatedTransfers);
+      txParts = this.tryToPrepareTransfers(accountBalance, feeGwei, groupedNotesBalances.slice(i, i + aggregatedTransfers.length), aggregatedTransfers);
       if (txParts.length == aggregatedTransfers.length) {
         // We are able to perform all txs starting from this index
         return aggregationParts.concat(txParts);
@@ -1226,7 +1226,7 @@ export class ZkBobClient {
         break;
       }
 
-      let inNotesBalance = groupedNotesBalances[i];
+      const inNotesBalance = groupedNotesBalances[i];
       if (accountBalance + inNotesBalance < feeGwei) {
         // We cannot collect amount to cover tx fee. There are 2 cases:
         // insufficient balance or unoperable notes configuration
@@ -1248,11 +1248,11 @@ export class ZkBobClient {
   }
 
   // try to prepare transfer configs
-  private getTransferConfigs(balance: bigint, fee: bigint, groupedNotesBalances: Array<bigint>, transfers: MultinoteTransferRequest[]): Array<TransferConfig> {
+  private tryToPrepareTransfers(balance: bigint, fee: bigint, groupedNotesBalances: Array<bigint>, transfers: MultinoteTransferRequest[]): Array<TransferConfig> {
     let accountBalance = balance;
     let parts: Array<TransferConfig> = [];
     for (let i = 0; i < transfers.length; i++) {
-      let inNotesBalance = i < groupedNotesBalances.length ? groupedNotesBalances[i] : BigInt(0);
+      const inNotesBalance = i < groupedNotesBalances.length ? groupedNotesBalances[i] : BigInt(0);
 
       if (accountBalance + inNotesBalance < transfers[i].totalAmount + fee) {
         // We haven't enough funds to perform such tx

--- a/src/client.ts
+++ b/src/client.ts
@@ -1156,13 +1156,9 @@ export class ZkBobClient {
 
     const txFee = await this.atomicTxFee(tokenAddress);
     const groupedNotesBalances = await this.getGroupedNotes(tokenAddress);
-    
     let accountBalance = await state.accountBalance();
-    if (groupedNotesBalances.length == 0) {
-      return accountBalance > txFee ? accountBalance - txFee : BigInt(0);
-    }
 
-    let maxAmount = BigInt(0);
+    let maxAmount = accountBalance > txFee ? accountBalance - txFee : BigInt(0);
     for (const inNotesBalance of groupedNotesBalances) {
       if (accountBalance + inNotesBalance < txFee) {
         break;

--- a/src/history.ts
+++ b/src/history.ts
@@ -13,8 +13,6 @@ export enum HistoryTransactionType {
   TransferIn,
   TransferOut,
   Withdrawal,
-  // DEPRECATED. Please use TokensMoving.isLoopback property instead
-  TransferLoopback,
   AggregateNotes,
 }
 
@@ -105,13 +103,6 @@ export class HistoryRecord {
     const action: TokensMoving = {from: "", to, amount, isLoopback: false};
     const state: HistoryRecordState = pending ? HistoryRecordState.Pending : HistoryRecordState.Mined;
     return new HistoryRecord(HistoryTransactionType.Withdrawal, ts, [action], fee, txHash, state);
-  }
-
-  // DEPRECATED method. Loopback is a TokenMoving property now
-  public static transferLoopback(to: string, amount: bigint, fee: bigint, ts: number, txHash: string, pending: boolean): HistoryRecord {
-    const action: TokensMoving = {from: "", to, amount, isLoopback: true};
-    const state: HistoryRecordState = pending ? HistoryRecordState.Pending : HistoryRecordState.Mined;
-    return new HistoryRecord(HistoryTransactionType.TransferLoopback, ts, [action], fee, txHash, state);
   }
 
   public static async aggregateNotes(


### PR DESCRIPTION
This PR is introducing a new multitransfer/multiwithdrawal notes aggregation strategy that is described in #88. The difference from the old approach can be demonstrated through the following example:

Let's suppose that account with a balance of 0.2 BOB has 4 notes with 1 BOB. We want to transfer 4 BOB to a receiver.
1. With the old approach it will be:
![image](https://user-images.githubusercontent.com/17165678/213689417-47480064-0db9-4b77-bd5c-e20bc19dcb54.png)
2. With the new approach:
![image](https://user-images.githubusercontent.com/17165678/213689979-b4e1adf0-c3fc-42e1-8fa7-f6bd9d8bab73.png)

It is worth noting that these schemes aren't equivalent in general. If we allow performing txs where the total balance is decreasing (if input notes don't cover the fee) there are some cases when the old approach can't execute some txs when the new one can and vice versa. 