### PR TITLE
Improving history synchronization

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -628,7 +628,9 @@ export class HistoryStorage {
   private async convertToHistory(memo: DecryptedMemo, pending: boolean, getIsLoopback: (shieldedAddress: string) => Promise<boolean>): Promise<HistoryRecordIdx[]> {
     const txHash = memo.txHash;
     if (txHash) {
-      const txData = await this.web3.eth.getTransaction(txHash);
+      // TODO: temporary random tx requests failuring
+      // Do not forget to remove (Math.random() <= ...) that!
+      const txData = (Math.random() <= 0.8) ? await this.web3.eth.getTransaction(txHash) : null;
       if (txData && txData.blockNumber && txData.input) {
           const block = await this.web3.eth.getBlock(txData.blockNumber);
           if (block) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -715,11 +715,9 @@ export class HistoryStorage {
   private async convertToHistory(memo: DecryptedMemo, pending: boolean, getIsLoopback: (shieldedAddress: string) => Promise<boolean>): Promise<HistoryRecordIdx[]> {
     const txHash = memo.txHash;
     if (txHash) {
-      // TODO: temporary random tx requests failuring
-      // Do not forget to remove (Math.random() <= ...) that!
       let txData;
       try {
-        txData = (Math.random() <= 0.8) ? await this.web3.eth.getTransaction(txHash) : null;
+        txData = await this.web3.eth.getTransaction(txHash);
       } catch (err) {
         txData = null;
       }
@@ -727,7 +725,7 @@ export class HistoryStorage {
           //const block = await this.web3.eth.getBlock(txData.blockNumber);
           let block;
           try {
-            block = (Math.random() <= 0.95) ? await this.web3.eth.getBlock(txData.blockNumber) : null;
+            block = await this.web3.eth.getBlock(txData.blockNumber);
           } catch (err) {
             block = null;
           }

--- a/src/history.ts
+++ b/src/history.ts
@@ -312,7 +312,6 @@ export class HistoryStorage {
 
     await this.syncHistoryPromise;
 
-    const startTimer = Date.now();
     return Array.from(this.currentHistory.values())
             .concat(this.failedHistory)
             .sort((rec1, rec2) => 0 - (rec1.timestamp > rec2.timestamp ? -1 : 1));
@@ -626,7 +625,6 @@ export class HistoryStorage {
           return records;
         });
         historyPromises.push(hist);
-        //processedIndexes.push(oneMemo.index);
       }
 
       // process pending memos
@@ -716,15 +714,14 @@ export class HistoryStorage {
     const txHash = memo.txHash;
     if (txHash) {
       let txData;
-      try {
+      try { // TODO: will be moved to the separated RPC requester
         txData = await this.web3.eth.getTransaction(txHash);
       } catch (err) {
         txData = null;
       }
       if (txData && txData.blockNumber && txData.input) {
-          //const block = await this.web3.eth.getBlock(txData.blockNumber);
           let block;
-          try {
+          try { // TODO: will be moved to the separated RPC requester
             block = await this.web3.eth.getBlock(txData.blockNumber);
           } catch (err) {
             block = null;


### PR DESCRIPTION
## This PR was introduces to avoid history record omitting case

To produce history record from the memo-block (received from the relayer) the library must receive associated transaction calldata from the RPC endpoint. Sometimes history record generating can be failed due to RPC inconsistence or other reasons. Previously in that case the history record was skipped. To restore it the user should start full sync again. The changes introduced by this PR help do not forget about that records.

**Behaviour pattern:**
1. Failed to sync transactions are saved separately in the Indexed DB
2. The sync routine will relaunch automatically in case of any errors
3. The relaunch attempts number are limited by an internal constant (currently 3 times)
4. Processed history records are returned anyway after all attempts (including the case when one or more records were not generated)
5. Failed to sync transactions will requested in the next history retrieving anyway (including a case when library will reload)

After the first launch library will check the user's history storage consistency to find a omitted records (to restore in the next history sync)

To test this branch please use the [console develop branch](https://github.com/zkBob/zkbob-console/tree/develop)

#95 
