### PR TITLE
Add Cache-Control header for requesting verification keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,8 +43,9 @@ const obj = {
     txParser = wasm.TxParser._new()
 
     console.time(`VK initializing`);
-    transferVk = await (await fetch(vkUrls.transferVkUrl)).json();
-    treeVk = await (await fetch(vkUrls.treeVkUrl)).json();
+    const noCacheHeader = { method: 'GET', headers: { 'Cache-Control': 'no-cache' } };
+    transferVk = await (await fetch(vkUrls.transferVkUrl, noCacheHeader)).json();
+    treeVk = await (await fetch(vkUrls.treeVkUrl, noCacheHeader)).json();
     console.timeEnd(`VK initializing`);
 
     console.info('Web worker init complete.');


### PR DESCRIPTION
To force update verification keys on the client side we should to add `Cache-Control : no-cache` request header