### PR TITLE
Workaround for the RPC freezing case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",


### PR DESCRIPTION
In some cases the RPC node can be frozen. In that case the node doesn't know anything about last pool contract state. The library should get the pool latest root when syncing the state. In that case RCP node returns zero root therefore the library assume the local state is invalid and fall into resync. I have prepared a workaround in that PR to prevent such case