### PR TITLE
Refactoring/fix vk fetch

### DIFF
--- a/src/file-cache.ts
+++ b/src/file-cache.ts
@@ -33,7 +33,7 @@ export class FileCache {
     let data = await this.get(path);
     if (!data) {
       console.log(`Caching ${path}`)
-      data = await this.cache(path);
+      data = await this.cache(path, loadingCallback);
     } else {
       console.log(`File ${path} is present in cache, no need to fetch`);
     }
@@ -42,7 +42,7 @@ export class FileCache {
   }
 
   public async cache(path: string, loadingCallback: LoadingProgressCallback | undefined = undefined): Promise<ArrayBuffer> {
-    const response = await fetch(path);
+    const response = await fetch(path, { headers: { 'Cache-Control': 'no-cache' } });
 
     if (response.status == 200 && response.body) {
       const reader = response.body.getReader();  

--- a/src/params.ts
+++ b/src/params.ts
@@ -44,21 +44,20 @@ export class SnarkParams {
     }
 
     // VKs are much smaller than params so we can refetch it in case any errors
+    // VK doesn't stored at the local storage (no verification ability currently)
     public async getVk(): Promise<any> {
         let attempts = 0;
         while (!this.isVkReady() && attempts++ < MAX_VK_LOAD_ATTEMPTS) {
           console.time(`VK initializing`);
           try {
-            const cache = await this.fileCache();
-            let vkData = await cache.getOrCache(this.vkUrl);
-            const vk = JSON.parse(Buffer.from(vkData).toString('utf8'));
+            const vk = await (await fetch(this.vkUrl, { headers: { 'Cache-Control': 'no-cache' } })).json();
             // verify VK structure
             if (typeof vk === 'object' && vk !== null &&
-                vk.hasOwnProperty('alpha') && typeof Array.isArray(vk.alpha) &&
-                vk.hasOwnProperty('beta') && typeof Array.isArray(vk.beta) &&
-                vk.hasOwnProperty('gamma') && typeof Array.isArray(vk.gamma) &&
-                vk.hasOwnProperty('delta') && typeof Array.isArray(vk.delta) &&
-                vk.hasOwnProperty('ic') && typeof Array.isArray(vk.uc))
+                vk.hasOwnProperty('alpha') && Array.isArray(vk.alpha) &&
+                vk.hasOwnProperty('beta') && Array.isArray(vk.beta) &&
+                vk.hasOwnProperty('gamma') && Array.isArray(vk.gamma) &&
+                vk.hasOwnProperty('delta') && Array.isArray(vk.delta) &&
+                vk.hasOwnProperty('ic') && Array.isArray(vk.ic))
             {
                 this.vk = vk;
             } else {
@@ -67,7 +66,7 @@ export class SnarkParams {
 
             this.vk = vk;
           } catch(err) {
-            console.warn(`Cannot load verification key: ${err.message}`);
+            console.warn(`VK loading attempt has failed: ${err.message}`);
           } finally {
             console.timeEnd(`VK initializing`);
           }

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,6 +1,8 @@
 import { InternalError } from "./errors";
 import { FileCache } from "./file-cache";
 
+const MAX_VK_LOAD_ATTEMPTS = 3;
+
 export enum LoadingStatus {
     NotStarted = 0,
     InProgress,
@@ -8,29 +10,77 @@ export enum LoadingStatus {
     Failed
 }
 
+// The class controls both the SNARK params and associated verification key
+// You can initiate param/vk loading independently when needed
 export class SnarkParams {
-    private url: string;
-    private expectedHash: string | undefined;
+    private paramUrl: string;
+    private vkUrl: string;
+    private expectedHash: string | undefined;   // only params verified by a hash
+
+    private cache: FileCache;
+
+    // params - wasm object (from binary), vk - json
     private params: any | undefined;
+    private vk: any | undefined;
+    
+    // covers only params not vk
     private loadingPromise: Promise<any> | undefined;
     private loadingStatus: LoadingStatus;
 
-    public constructor(url: string, expectedHash: string | undefined) {
+    public constructor(paramUrl: string, vkUrl: string, expectedParamHash: string | undefined) {
         this.loadingStatus = LoadingStatus.NotStarted;
-        this.url = url;
-        this.expectedHash = expectedHash;
+        this.paramUrl = paramUrl;
+        this.vkUrl = vkUrl;
+        this.expectedHash = expectedParamHash;
     }
 
-    public async get(wasm: any): Promise<any> {
-        if (this.isParamsReady()) {
-            return this.params;
+    public async getParams(wasm: any): Promise<any> {
+        if (!this.isParamsReady()) {
+            this.loadParams(wasm);
+            return await this.loadingPromise;
         }
-        
-        this.load(wasm);
-        return await this.loadingPromise;
+
+        return this.params;
     }
 
-    public load(wasm: any) {
+    // VKs are much smaller than params so we can refetch it in case any errors
+    public async getVk(): Promise<any> {
+        let attempts = 0;
+        while (!this.isVkReady() && attempts++ < MAX_VK_LOAD_ATTEMPTS) {
+          console.time(`VK initializing`);
+          try {
+            const cache = await this.fileCache();
+            let vkData = await cache.getOrCache(this.vkUrl);
+            const vk = JSON.parse(Buffer.from(vkData).toString('utf8'));
+            // verify VK structure
+            if (typeof vk === 'object' && vk !== null &&
+                vk.hasOwnProperty('alpha') && typeof Array.isArray(vk.alpha) &&
+                vk.hasOwnProperty('beta') && typeof Array.isArray(vk.beta) &&
+                vk.hasOwnProperty('gamma') && typeof Array.isArray(vk.gamma) &&
+                vk.hasOwnProperty('delta') && typeof Array.isArray(vk.delta) &&
+                vk.hasOwnProperty('ic') && typeof Array.isArray(vk.uc))
+            {
+                this.vk = vk;
+            } else {
+                throw new InternalError(`The object isn't a valid VK`);
+            }
+
+            this.vk = vk;
+          } catch(err) {
+            console.warn(`Cannot load verification key: ${err.message}`);
+          } finally {
+            console.timeEnd(`VK initializing`);
+          }
+        }
+
+        if (!this.isVkReady()) {
+            throw new InternalError(`Cannot load a valid VK after ${MAX_VK_LOAD_ATTEMPTS} attempts`);
+        }
+
+        return this.vk;
+      }
+
+    private loadParams(wasm: any) {
         if (this.isParamsReady() || this.loadingStatus == LoadingStatus.InProgress) {
             return;
         }
@@ -38,23 +88,23 @@ export class SnarkParams {
         this.loadingStatus = LoadingStatus.InProgress;
         this.loadingPromise = new Promise(async (resolve, reject) => {
             try {
-                const cache = await FileCache.init();
+                const cache = await this.fileCache();
 
                 console.time(`Load parameters from DB`);
-                let txParamsData = await cache.get(this.url)
+                let txParamsData = await cache.get(this.paramUrl)
                     .finally(() => console.timeEnd(`Load parameters from DB`));
 
                 // check parameters hash if needed
                 if (txParamsData && this.expectedHash !== undefined) {
-                    let computedHash = await cache.getHash(this.url);
+                    let computedHash = await cache.getHash(this.paramUrl);
                     if (!computedHash) {
-                        computedHash = await cache.saveHash(this.url, txParamsData);
+                        computedHash = await cache.saveHash(this.paramUrl, txParamsData);
                     }
 
                     if (computedHash.toLowerCase() != this.expectedHash.toLowerCase()) {
                         // forget saved params in case of hash inconsistence
-                        console.warn(`Hash of cached tx params (${computedHash}) doesn't associated with provided (${this.url}).`);
-                        cache.remove(this.url);
+                        console.warn(`Hash of cached tx params (${computedHash}) doesn't associated with provided (${this.paramUrl}).`);
+                        cache.remove(this.paramUrl);
                         txParamsData = null;
                     }
                 }
@@ -62,7 +112,7 @@ export class SnarkParams {
                 let params;
                 if (!txParamsData) {
                     console.time(`Download params`);
-                    txParamsData = await cache.cache(this.url)
+                    txParamsData = await cache.cache(this.paramUrl)
                         .finally(() => console.timeEnd(`Download params`));
 
                     try {
@@ -72,7 +122,7 @@ export class SnarkParams {
                         console.timeEnd(`Creating Params object`);
                     }
                 } else {
-                    console.log(`File ${this.url} is present in cache, no need to fetch`);
+                    console.log(`File ${this.paramUrl} is present in cache, no need to fetch`);
 
                     try {
                         console.time(`Creating Params object`);
@@ -98,6 +148,18 @@ export class SnarkParams {
 
     private isParamsReady(): boolean {
         return this.params !== undefined;
+    }
+
+    private isVkReady(): boolean {
+        return this.vk !== undefined;
+    }
+
+    private async fileCache(): Promise<FileCache> {
+        if (!this.cache) {
+            this.cache = await FileCache.init();
+        }
+
+        return this.cache;
     }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,8 +9,6 @@ import { SnarkParams } from './params';
 let txParams: SnarkParams;
 let txParser: any;
 let zpAccounts: { [accountId: string]: any } = {};
-let transferVk: any;
-let treeVk: any;
 
 let wasm: any;
 
@@ -40,7 +38,10 @@ const obj = {
     }
 
     txParams = new SnarkParams(txParamsUrl, txVkUrl, txParamsHash);
-    txParams.getVk(); // VK is always needed to transact, so initiate its loading right now
+    // VK is always needed to transact, so initiate its loading right now
+    txParams.getVk().catch((err) => {
+      console.warn(`Unable to fetch tx verification key (don't worry, it will refetched when needed): ${err.message}`);
+    });
 
     txParser = wasm.TxParser._new()
 
@@ -174,7 +175,7 @@ const obj = {
   },
 
   async verifyTxProof(inputs: string[], proof: SnarkProof): Promise<boolean> {
-    const vk = await txParams.getVk();
+    const vk = await txParams.getVk();  // will throw error if VK fetch fail
     return wasm.Proof.verify(vk, inputs, proof);
   },
 


### PR DESCRIPTION
Here is a workaround for the following bug 
<img width="839" alt="image" src="https://user-images.githubusercontent.com/1415489/229846637-a1455c00-7fbd-4a8e-8291-d4ccfe88d04d.png">

This bug in Sentry: https://zkbob-1m.sentry.io/issues/3959524876/?project=4504022246490112

It was caused due to on the application start VK was not fetched properly for a some reason. This PR introduces refetching VK within several attempts. The tree proving/verification code was removed as well