### PR TITLE
Feature/gift card codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "regenerator-runtime": "^0.13.9",
     "wasm-feature-detect": "^1.2.11",
     "web3": "1.8.0",
-    "web3-utils": "1.8.0"
+    "web3-utils": "1.8.0",
+    "bs58": "5.0.0"
   },
   "devDependencies": {
     "@types/ethereum-protocol": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -7,6 +7,7 @@ import { ServiceVersion } from "./services/common";
 import { ZkBobDelegatedProver } from "./services/prover";
 import { LimitsFetch, ZkBobRelayer } from "./services/relayer";
 import { ColdStorageConfig } from "./coldstorage";
+import { bufToHex, HexStringReader, HexStringWriter, hexToBuf, truncateHexPrefix } from "./utils";
 
 const LIB_VERSION = require('../package.json').version;
 
@@ -14,6 +15,7 @@ const DEFAULT_DENOMINATOR = BigInt(1000000000);
 const RELAYER_FEE_LIFETIME = 3600;  // when to refetch the relayer fee (in seconds)
 const DEFAULT_RELAYER_FEE = BigInt(100000000);
 const MIN_TX_AMOUNT = BigInt(50000000);
+const GIFT_CARD_CODE_VER = 1;
 
 // relayer fee + fetching timestamp
 interface RelayerFeeFetch {
@@ -53,6 +55,13 @@ export interface TreeState {
 export interface ChainConfig {
     backend: NetworkBackend;
     networkName: string;
+}
+
+export class GiftCardProperties {
+    sk: Uint8Array;
+    birthIndex: bigint;
+    balance: bigint;
+    poolAlias: string;
 }
 
 // Provides base functionality for the zkBob solution
@@ -525,5 +534,66 @@ export class ZkBobProvider {
         }
         
         return prover.version();
+    }
+
+    // ------------------=========< Other Routines >=========----------------------
+    // | Helpers                                                                  |
+    // ----------------------------------------------------------------------------
+
+    public async codeForGiftCard(giftCard: GiftCardProperties): Promise<string> {
+        const pool = this.pools[giftCard.poolAlias];
+        if (!pool) {
+            throw new InternalError(`Unknown pool in gift-card properties: ${giftCard.poolAlias}`);
+        }
+
+        if (giftCard.sk.length != 32) {
+            throw new InternalError('The gift-card spending key should be 32 bytes length');
+        }
+
+
+        const writer = new HexStringWriter();
+        writer.writeNumber(GIFT_CARD_CODE_VER, 1);
+        writer.writeHex(bufToHex(giftCard.sk));
+        writer.writeBigInt(giftCard.birthIndex, 6);
+        writer.writeHex(pool.poolAddress.slice(-8));
+        writer.writeNumber(pool.chainId, 4);
+        writer.writeBigInt(giftCard.balance, 8);
+
+        return truncateHexPrefix(writer.toString());
+    }
+
+    public async giftCardFromCode(code: string): Promise<GiftCardProperties> {
+        const reader = new HexStringReader(code);
+        
+        const codeVer = reader.readNumber(1);
+        if (codeVer == null) {
+            throw new InternalError('Incorrect code for the gift-card');
+        }
+        if (codeVer > GIFT_CARD_CODE_VER) {
+            throw new InternalError(`The gift-card code version ${codeVer} isn't supported`);
+        }
+
+        const sk = reader.readHex(32);
+        const birthIndex = reader.readBigInt(6);
+        const poolAddrSlice = reader.readHex(4);
+        const chainId = reader.readNumber(4);
+        const balance = reader.readBigInt(8);
+        if (sk == null || birthIndex == null || poolAddrSlice == null || chainId == null || balance == null) {
+            throw new InternalError('Incorrect code for the gift-card');
+        }
+        
+        let poolAlias: string | undefined = undefined;
+        for (const [alias, pool] of Object.entries(this.pools)) {
+            if (pool.chainId == chainId && pool.poolAddress.slice(-8) == poolAddrSlice) {
+                poolAlias = alias;
+                break;
+            }
+        }
+
+        if (!poolAlias) {
+            throw new InternalError(`Uncnown pool in the gift-carg code (chainId = ${chainId}, endOfPoolAddr = ${poolAddrSlice})`);
+        }
+
+        return { sk: hexToBuf(sk), birthIndex, balance, poolAlias };
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { ClientConfig, AccountConfig, accountId,
         SnarkConfigParams,
       } from './config';
 export { ZkBobClient, TransferConfig, TransferRequest, FeeAmount } from './client';
-export { ZkBobProvider as ZkBobAccountlessClient } from './client-provider';
+export { ZkBobProvider as ZkBobAccountlessClient, GiftCardProperties } from './client-provider';
 export { SyncStat } from './state';
 export { TxType } from './tx';
 export { HistoryRecord, HistoryTransactionType, HistoryRecordState } from './history';

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,6 +820,11 @@ base-x@^3.0.2, base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -1027,6 +1032,13 @@ browserslist@^4.14.5:
     electron-to-chromium "^1.4.251"
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
+
+bs58@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
 
 bs58@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
Introduced new functions for encoding/decoding gift cards in the URL query:
 - `codeForGiftCard`: make a code
 - `giftCardFromCode`: parse given code and return GiftCardProperties object:
```
export class GiftCardProperties {
    sk: Uint8Array;
    birthIndex: bigint;
    balance: bigint;
    poolAlias: string;
}
```

It covered in Base58 to reduce total length. Currently normal length is 74 bytes
The code has version control byte as well

Decoding example:
`YQqjYiZ2NP3LqLRYRHKps445utysC2KSDWHBKiv52JF6wZWANu3cXpLzH7oTbyyVwqKD92GPC3` 
 -> `018597022fe976bfc9a1ae5a40ae00d4619ff7068590d313f5e2912d0ac3f1610100000000058054126596000001a4000000003b9aca00`
 - `0x01` - code version
 - `0x8597022fe976bfc9a1ae5a40ae00d4619ff7068590d313f5e2912d0ac3f16101`  - sk
 - `0x000000000580 (1408)` - birthIndex
 - `0x54126596` - the pool contract address (last 4 bytes)
 - `0x000001a4 (420)`  - chainId
 - `0x000000003b9aca00 (1,000,000,000)` - gift-card nominal balance (1 BOB, Gwei)

Please feel free to check it with the [associated console branch](https://github.com/zkBob/zkbob-console/tree/feature/gift-card-codes)
Associated zkbob-console PR: https://github.com/zkBob/zkbob-console/pull/71