### PR TITLE
Set required prover mode during gift-card redeeming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -61,7 +61,7 @@ export interface ChainConfig {
 
 export class GiftCardProperties {
     sk: Uint8Array;
-    birthIndex: bigint;
+    birthIndex: number;
     balance: bigint;
     poolAlias: string;
 }
@@ -556,7 +556,7 @@ export class ZkBobProvider {
         const writer = new HexStringWriter();
         writer.writeNumber(GIFT_CARD_CODE_VER, 1);
         writer.writeHex(bufToHex(giftCard.sk));
-        writer.writeBigInt(giftCard.birthIndex, 6);
+        writer.writeNumber(giftCard.birthIndex, 6);
         writer.writeHex(pool.poolAddress.slice(-8));
         writer.writeNumber(pool.chainId, 4);
         writer.writeBigInt(giftCard.balance, 8);
@@ -577,7 +577,7 @@ export class ZkBobProvider {
         }
 
         const sk = reader.readHex(32);
-        const birthIndex = reader.readBigInt(6);
+        const birthIndex = reader.readNumber(6);
         const poolAddrSlice = reader.readHex(4);
         const chainId = reader.readNumber(4);
         const balance = reader.readBigInt(8);

--- a/src/client.ts
+++ b/src/client.ts
@@ -902,7 +902,7 @@ export class ZkBobClient extends ZkBobProvider {
     const txData = await giftCardState.createTransferOptimistic(oneTx, this.zeroOptimisticState());
 
     const startProofDate = Date.now();
-    const txProof: Proof = await this.proveTx(txData.public, txData.secret);
+    const txProof: Proof = await this.proveTx(txData.public, txData.secret, giftCardAcc.proverMode);
     const proofTime = (Date.now() - startProofDate) / 1000;
     console.log(`Proof calculation took ${proofTime.toFixed(1)} sec`);
 
@@ -1195,8 +1195,8 @@ export class ZkBobClient extends ZkBobProvider {
   }
 
   // Universal proving routine
-  private async proveTx(pub: any, sec: any): Promise<any> {
-    const proverMode = this.getProverMode();
+  private async proveTx(pub: any, sec: any, forcedMode: ProverMode | undefined = undefined): Promise<any> {
+    const proverMode = forcedMode ?? this.getProverMode();
     const prover = this.prover()
     if ((proverMode == ProverMode.Delegated || proverMode == ProverMode.DelegatedWithFallback) && prover) {
       console.debug('Delegated Prover: proveTx');


### PR DESCRIPTION
This PR fix the issue when the library wasn't use the delegated prover during gift card redeeming (in case of associated mode was set for gift-card account)

Associated console PR: https://github.com/zkBob/zkbob-console/pull/76