### PR TITLE
Swap pool token support for withdrawal transactions

### DIFF
--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -15,6 +15,7 @@ const LIB_VERSION = require('../package.json').version;
 
 const DEFAULT_DENOMINATOR = BigInt(1000000000);
 const RELAYER_FEE_LIFETIME = 3600;  // when to refetch the relayer fee (in seconds)
+const NATIVE_AMOUNT_LIFETIME = 3600;  // when to refetch the max supported swap amount (in seconds)
 const DEFAULT_RELAYER_FEE = BigInt(100000000);
 const MIN_TX_AMOUNT = BigInt(50000000);
 const GIFT_CARD_CODE_VER = 1;
@@ -23,6 +24,12 @@ const GIFT_CARD_CODE_VER = 1;
 interface RelayerFeeFetch {
     fee: bigint;
     timestamp: number;  // when the fee was fetched
+}
+
+// max supported swap amount + fetching timestamp
+interface MaxSwapAmountFetch {
+    amount: bigint;
+    timestamp: number;  // when amount was fetched
 }
 
 export interface Limit { // all values are in Gwei
@@ -78,6 +85,7 @@ export class ZkBobProvider {
     private denominators:   { [name: string]: bigint } = {};
     private poolIds:        { [name: string]: number } = {};
     private relayerFee:     { [name: string]: RelayerFeeFetch } = {};
+    private maxSwapAmount:  { [name: string]: MaxSwapAmountFetch } = {};
     private coldStorageCfg: { [name: string]: ColdStorageConfig } = {};
     protected supportId: string | undefined;
 
@@ -319,12 +327,33 @@ export class ZkBobProvider {
                 cachedFee = {fee, timestamp: Date.now()};
                 this.relayerFee[this.curPool] = cachedFee;
             } catch (err) {
-                console.error(`Cannot fetch relayer fee, will using default (${DEFAULT_RELAYER_FEE}): ${err}`);
-                return this.relayerFee[this.curPool]?.fee ?? DEFAULT_RELAYER_FEE;
+                const res = this.relayerFee[this.curPool]?.fee ?? DEFAULT_RELAYER_FEE;
+                console.error(`Cannot fetch relayer fee, will using default (${res}): ${err}`);
+
+                return res;
             }
         }
 
         return cachedFee.fee;
+    }
+
+    // Max supported token swap during withdrawal, in token resolution (Gwei)
+    public async maxSupportedTokenSwap(): Promise<bigint> {
+        let cachedAmount = this.maxSwapAmount[this.curPool];
+        if (!cachedAmount || cachedAmount.timestamp + NATIVE_AMOUNT_LIFETIME * 1000 < Date.now()) {
+            try {
+                const amount = await this.relayer().maxSupportedSwapAmount();
+                cachedAmount = {amount, timestamp: Date.now()};
+                this.maxSwapAmount[this.curPool] = cachedAmount;
+            } catch (err) {
+                const res = this.maxSwapAmount[this.curPool]?.amount ?? 0;
+                console.warn(`Cannot fetch max available swap amount, will using default (${res}): ${err}`);
+
+                return res;
+            }
+        }
+
+        return cachedAmount.amount;
     }
 
     public async directDepositFee(): Promise<bigint> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import { EphemeralAddress } from './ephemeral';
 import { Proof, ITransferData, IWithdrawData, StateUpdate, TreeNode, IAddressComponents } from 'libzkbob-rs-wasm-web';
 import { 
   InternalError, PoolJobError, RelayerJobError, SignatureError, TxDepositDeadlineExpiredError,
-  TxInsufficientFundsError, TxInvalidArgumentError, TxLimitError, TxProofError, TxSmallAmount
+  TxInsufficientFundsError, TxInvalidArgumentError, TxLimitError, TxProofError, TxSmallAmount, TxSwapTooHighError
 } from './errors';
 import { isHexPrefixed } from '@ethereumjs/util';
 import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util';
@@ -792,6 +792,11 @@ export class ZkBobClient extends ZkBobProvider {
       throw new TxInvalidArgumentError('Please provide a valid non-zero address');
     }
     const addressBin = ethAddrToBuf(address);
+
+    const supportedSwapAmount = await this.maxSupportedTokenSwap();
+    if (swapAmount > supportedSwapAmount) {
+      throw new TxSwapTooHighError(swapAmount, supportedSwapAmount);
+    }
 
     const minTx = await this.minTxAmount();
     if (amountGwei < minTx) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -779,7 +779,7 @@ export class ZkBobClient extends ZkBobProvider {
   // This method can produce several transactions in case of insufficient input notes (constants::IN per tx)
   // feeGwei - fee per single transaction (request it with atomicTxFee method)
   // Returns jobId from the relayer or throw an Error
-  public async withdrawMulti(address: string, amountGwei: bigint, feeGwei: bigint = BigInt(0)): Promise<string[]> {
+  public async withdrawMulti(address: string, amountGwei: bigint, swapAmount: bigint, feeGwei: bigint = BigInt(0)): Promise<string[]> {
     const relayer = this.relayer();
     const state = this.zpState();
 
@@ -830,7 +830,7 @@ export class ZkBobClient extends ZkBobProvider {
           amount: onePart.outNotes[0].amountGwei.toString(),
           fee: onePart.fee.toString(),
           to: addressBin,
-          native_amount: '0',
+          native_amount: swapAmount.toString(),
           energy_amount: '0',
         };
         oneTxData = await state.createWithdrawalOptimistic(oneTx, optimisticState);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -74,6 +74,16 @@ export class TxInsufficientFundsError extends BobError {
     }
 }
 
+export class TxSwapTooHighError extends BobError {
+    public requested: bigint;
+    public supported: bigint;
+    constructor(requested: bigint, supported: bigint) {
+        super(`The pool doesn't support requested swap amount (requested ${requested.toString()}, supported ${supported.toString()})`);
+        this.requested = requested;
+        this.supported = supported;
+    }
+}
+
 export class ServiceError extends BobError {
     public code: number;
     public service: ServiceType;

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -270,7 +270,7 @@ export class ZkBobRelayer implements IZkBobService {
     const res = await fetchJson(url.toString(), {headers}, this.type());
 
     if (typeof res !== 'object' || res === null ||
-        !res.hasOwnProperty('maxNativeAmount') || typeof res.hash !== 'string')
+        !res.hasOwnProperty('maxNativeAmount') || typeof res.maxNativeAmount !== 'string')
     {
       throw new ServiceError(this.type(), 200, 'Incorrect respons for /maxNativeAmount');
     }

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -261,4 +261,20 @@ export class ZkBobRelayer implements IZkBobService {
   
     return res.hash;
   }
+
+  // Amount of the pool tokens which could be swapped to the native ones
+  // in a single withdrawal transaction (aka native_amount)
+  public async maxSupportedSwapAmount(): Promise<bigint> {
+    const url = new URL('/maxNativeAmount', this.url());
+    const headers = defaultHeaders();
+    const res = await fetchJson(url.toString(), {headers}, this.type());
+
+    if (typeof res !== 'object' || res === null ||
+        !res.hasOwnProperty('maxNativeAmount') || typeof res.hash !== 'string')
+    {
+      throw new ServiceError(this.type(), 200, 'Incorrect respons for /maxNativeAmount');
+    }
+  
+    return BigInt(res.maxNativeAmount);
+  }
 }


### PR DESCRIPTION
Support tokens swapping to the native ones during the withdrawal transaction.

Current changes suppose the relayer has `/maxNativeAmount` endpoint  (https://github.com/zkBob/zeropool-relayer/pull/175). The client library compares requested swap amount with relayer's response (transactions with higher swap amount will be rejected). If relayer doesn't support `/maxNativeAmount` endpoint we assume the max available amount equals zero. 

The `native_amount` field in the memo for withdrawal tx contains tokens amount to swap (in pool resolution, i.e. Gwei)

Associated console PR: https://github.com/zkBob/zkbob-console/pull/80
