### PR TITLE
Dynamic fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -335,7 +335,7 @@ export class ZkBobProvider {
             const poolResDigits = (await this.decimals()) - denomLog;
             if (poolResDigits > feeDecimals) {
                 const rounder = 10n ** BigInt(poolResDigits - feeDecimals);
-                return (fee / rounder) * rounder + (fee % rounder > 0n ? rounder : 0n);
+                return fee % rounder > 0n ? fee + rounder - fee % rounder : fee;
             }
         }
 

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -310,8 +310,7 @@ export class ZkBobProvider {
     protected async roundFee(fee: bigint): Promise<bigint> {
         const feeDecimals = this.pool().feeDecimals;
         if (feeDecimals !== undefined) {
-            const denom = (await this.denominator()).toString();
-            const denomLog = denom.length + Math.log10(Number('0.' + denom.substring(0, 15)));
+            const denomLog = (await this.denominator()).toString().length - 1;
             const poolResDigits = 18 - denomLog;
             if (poolResDigits > feeDecimals) {
                 const rounder = 10n ** BigInt(poolResDigits - feeDecimals);

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -327,7 +327,7 @@ export class ZkBobProvider {
     // ----------------------------------------------------------------------------
 
     // Relayer raw fee components used to calculate concrete tx cost
-    // To estimate typycal fee for transaction with desired type please use atomicTxFee
+    // To estimate typical fee for transaction with desired type please use atomicTxFee
     public async getRelayerFee(): Promise<RelayerFee> {
         let cachedFee = this.relayerFee[this.curPool];
         if (!cachedFee || cachedFee.timestamp + RELAYER_FEE_LIFETIME * 1000 < Date.now()) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1115,7 +1115,7 @@ export class ZkBobClient extends ZkBobProvider {
     let accountBalance = await state.accountBalance();
 
     let maxAmount = accountBalance > aggregateTxFee ? accountBalance - aggregateTxFee : 0n;
-    for (var i = 0; i < groupedNotesBalances.length; i++) { //(const inNotesBalance of groupedNotesBalances) {
+    for (var i = 0; i < groupedNotesBalances.length; i++) { 
       const inNotesBalance = groupedNotesBalances[i];
       const txFee = (i == groupedNotesBalances.length - 1) ? finalTxFee : aggregateTxFee;
       if (accountBalance + inNotesBalance < txFee) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -942,7 +942,7 @@ export class ZkBobClient extends ZkBobProvider {
     return jobId;
   }
 
-  // DEPRECATED. Please use depositPermittableV2 method instead
+  // DEPRECATED. Please use depositPermittable method instead
   // Deposit throught approval allowance
   // User should approve allowance for contract address at least 
   // (amountGwei + feeGwei) tokens before calling this method
@@ -966,7 +966,7 @@ export class ZkBobClient extends ZkBobProvider {
     await this.updateState();
 
     const usedFee = relayerFee ?? await this.getRelayerFee();
-    const feeGwei = (await this.feeEstimateInternal([amountGwei], TxType.BridgeDeposit, usedFee, false)).total;
+    const feeGwei = (await this.feeEstimateInternal([amountGwei], TxType.Deposit, usedFee, false)).total;
 
     const txData = await state.createDeposit({
       amount: (amountGwei + feeGwei).toString(),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1068,9 +1068,10 @@ export class ZkBobClient extends ZkBobProvider {
 
       txCnt = parts.length > 0 ? parts.length : 1;  // if we haven't funds for atomic fee - suppose we can make one tx
       total = parts.map((p) => p.fee).reduce((acc, cur) => acc + cur, 0n);
-      calldataTotalLength = parts
-        .map((p) => p.outNotes.length)
-        .reduce((acc, cur) => acc + estimateCalldataLength(txType, cur), 0);
+      for (let i = 0; i < parts.length; i++) {
+        const curTxType = i < parts.length - 1 ? TxType.Transfer : txType;
+        calldataTotalLength += estimateCalldataLength(curTxType, curTxType == TxType.Transfer ? parts[i].outNotes.length : 0);
+      }
 
       insufficientFunds = (totalSumm < totalRequested || totalSumm + total > totalBalance) ? true : false;
     } else {
@@ -1172,7 +1173,6 @@ export class ZkBobClient extends ZkBobProvider {
         // We can't aggregate notes if we doesn't have one
         break;
       }
-
 
       const calldataBytesCnt = estimateCalldataLength(TxType.Transfer, 0);
       const fee = relayerFee.fee + relayerFee.oneByteFee * BigInt(calldataBytesCnt);

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export interface Pool {
   relayerUrls: string[];
   delegatedProverUrls: string[];
   coldStorageConfigPath?: string;
+  feeDecimals: number | undefined;
 }
 
 export enum ProverMode {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { ZkBobClient, TransferConfig, TransferRequest, FeeAmount } from './clien
 export { ZkBobProvider as ZkBobAccountlessClient, GiftCardProperties } from './client-provider';
 export { SyncStat } from './state';
 export { TxType } from './tx';
+export { RelayerFee } from './services/relayer'
 export { HistoryRecord, HistoryTransactionType, HistoryRecordState, ComplianceHistoryRecord } from './history';
 export { EphemeralAddress, EphemeralPool } from './ephemeral';
 export { ServiceType, ServiceVersion } from './services/common';

--- a/src/networks/evm-abi.ts
+++ b/src/networks/evm-abi.ts
@@ -29,6 +29,16 @@ export const tokenABI: AbiItem[] = [
         stateMutability: 'view',
         type: 'function'
     }, {
+        inputs: [],
+        name: 'decimals',
+        outputs: [{
+            internalType: 'uint8',
+            name: '',
+            type: 'uint8'
+        }],
+        stateMutability: 'view',
+        type: 'function'
+    }, {
         inputs: [{
             internalType: 'address',
             name: '',

--- a/src/networks/evm.ts
+++ b/src/networks/evm.ts
@@ -87,6 +87,11 @@ export class EvmNetwork implements NetworkBackend {
         this.tokenContract().options.address = tokenAddress;
         return await this.tokenContract().methods.name().call();
     }
+
+    public async getTokenDecimals(tokenAddress: string): Promise<number> {
+        this.tokenContract().options.address = tokenAddress;
+        return Number(await this.tokenContract().methods.decimals().call());
+    }
     
     public async getTokenNonce(tokenAddress: string, address: string): Promise<number> {
         this.tokenContract().options.address = tokenAddress;

--- a/src/networks/network.ts
+++ b/src/networks/network.ts
@@ -3,6 +3,7 @@ export interface NetworkBackend {
     setEnabled(enabled: boolean);
     getChainId(): Promise<number>;
     getTokenName(tokenAddress: string): Promise<string>;
+    getTokenDecimals(tokenAddress: string): Promise<number>;
     getTokenNonce(tokenAddress: string, address: string): Promise<number>;
     getTokenBalance(tokenAddress: string, address: string): Promise<bigint>;
     getDenominator(contractAddress: string): Promise<bigint>;

--- a/src/networks/polkadot.ts
+++ b/src/networks/polkadot.ts
@@ -13,6 +13,11 @@ export class PolkadotNetwork implements NetworkBackend {
         return '';
     }
 
+    async getTokenDecimals(_tokenAddress: string): Promise<number> {
+        return 1;
+    }
+    
+
     async getTokenNonce(_tokenAddress: string, _address: string): Promise<number> {
         return 0;
     }

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -220,7 +220,7 @@ export class ZkBobRelayer implements IZkBobService {
     const url = new URL('/fee', this.url());
     const headers = defaultHeaders(this.supportId);
     //const res = await fetchJson(url.toString(), {headers}, this.type());
-    const res = { fee: '100000000', oneByteFee: '97466'}; // TEST ONLY
+    const res = { fee: '100000000', oneByteFee: '90000'}; // TEST ONLY
 
     if (typeof res !== 'object' || res === null || !res.hasOwnProperty('fee')) {
       throw new ServiceError(this.type(), 200, 'Incorrect response for dynamic fees');

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -217,9 +217,10 @@ export class ZkBobRelayer implements IZkBobService {
   }
   
   public async fee(): Promise<RelayerFee> {
-    const url = new URL('/fee/v2', this.url());
+    const url = new URL('/fee', this.url());
     const headers = defaultHeaders(this.supportId);
-    const res = await fetchJson(url.toString(), {headers}, this.type());
+    //const res = await fetchJson(url.toString(), {headers}, this.type());
+    const res = { fee: '100000000', oneByteFee: '97466'}; // TEST ONLY
 
     if (typeof res !== 'object' || res === null || !res.hasOwnProperty('fee')) {
       throw new ServiceError(this.type(), 200, 'Incorrect response for dynamic fees');

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -219,8 +219,7 @@ export class ZkBobRelayer implements IZkBobService {
   public async fee(): Promise<RelayerFee> {
     const url = new URL('/fee', this.url());
     const headers = defaultHeaders(this.supportId);
-    //const res = await fetchJson(url.toString(), {headers}, this.type());
-    const res = { fee: '100000000', oneByteFee: '90000'}; // TEST ONLY
+    const res = await fetchJson(url.toString(), {headers}, this.type());
 
     if (typeof res !== 'object' || res === null || !res.hasOwnProperty('fee')) {
       throw new ServiceError(this.type(), 200, 'Incorrect response for dynamic fees');

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -47,7 +47,7 @@ const isRelayerInfo = (obj: any): obj is RelayerInfo => {
     obj.hasOwnProperty('optimisticDeltaIndex') && typeof obj.optimisticDeltaIndex === 'number';
 }
 
-export interface DynamicFee {
+export interface RelayerFee {
   fee: bigint;
   oneByteFee: bigint;
 }
@@ -216,14 +216,7 @@ export class ZkBobRelayer implements IZkBobService {
     throw new ServiceError(this.type(), 200, `Incorrect response (expected RelayerInfo, got \'${res}\')`)
   }
   
-  public async fee(): Promise<bigint> {
-    const url = new URL('/fee', this.url());
-    const headers = defaultHeaders(this.supportId);
-    const res = await fetchJson(url.toString(), {headers}, this.type());
-    return BigInt(res.fee);
-  }
-
-  public async feeV2(): Promise<DynamicFee> {
+  public async fee(): Promise<RelayerFee> {
     const url = new URL('/fee/v2', this.url());
     const headers = defaultHeaders(this.supportId);
     const res = await fetchJson(url.toString(), {headers}, this.type());

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -47,6 +47,11 @@ const isRelayerInfo = (obj: any): obj is RelayerInfo => {
     obj.hasOwnProperty('optimisticDeltaIndex') && typeof obj.optimisticDeltaIndex === 'number';
 }
 
+export interface DynamicFee {
+  fee: bigint;
+  oneByteFee: bigint;
+}
+
 interface Limit { // all values are in Gwei
   total: bigint;
   available: bigint;
@@ -217,6 +222,21 @@ export class ZkBobRelayer implements IZkBobService {
     const res = await fetchJson(url.toString(), {headers}, this.type());
     return BigInt(res.fee);
   }
+
+  public async feeV2(): Promise<DynamicFee> {
+    const url = new URL('/fee/v2', this.url());
+    const headers = defaultHeaders(this.supportId);
+    const res = await fetchJson(url.toString(), {headers}, this.type());
+
+    if (typeof res !== 'object' || res === null || !res.hasOwnProperty('fee')) {
+      throw new ServiceError(this.type(), 200, 'Incorrect response for dynamic fees');
+    }
+
+    return {
+      fee: BigInt(res.fee),
+      oneByteFee: BigInt(res.oneByteFee ?? '0')
+    };
+  }
   
   public async limits(address: string | undefined): Promise<LimitsFetch> {
     const url = new URL('/limits', this.url());
@@ -256,7 +276,7 @@ export class ZkBobRelayer implements IZkBobService {
     if (typeof res !== 'object' || res === null ||
         !res.hasOwnProperty('hash') || typeof res.hash !== 'string')
     {
-      throw new ServiceError(this.type(), 200, 'Incorrect respons for tx params hash');
+      throw new ServiceError(this.type(), 200, 'Incorrect response for tx params hash');
     }
   
     return res.hash;

--- a/src/tx.ts
+++ b/src/tx.ts
@@ -10,6 +10,14 @@ const MEMO_META_DEFAULT_SIZE: number = 8; // fee (u64)
 const MEMO_META_WITHDRAW_SIZE: number = 8 + 8 + 20; // fee (u64) + amount + address (u160)
 const MEMO_META_PERMITDEPOSIT_SIZE: number = 8 + 8 + 20; // fee (u64) + amount + address (u160)
 
+export const CALLDATA_BASE_LENGTH: number = 644;
+export const CALLDATA_MEMO_APPROVE_DEPOSIT_BASE_LENGTH: number = 210;
+export const CALLDATA_MEMO_DEPOSIT_BASE_LENGTH: number = 238;
+export const CALLDATA_MEMO_TRANSFER_BASE_LENGTH: number = 210;
+export const CALLDATA_MEMO_NOTE_LENGTH: number = 172;
+export const CALLDATA_MEMO_WITHDRAW_BASE_LENGTH: number = 238;
+export const CALLDATA_DEPOSIT_SIGNATURE_LENGTH: number = 64;
+
 export enum TxType {
   Deposit = '0000',
   Transfer = '0001',
@@ -24,6 +32,29 @@ export function txTypeToString(txType: TxType): string {
     case TxType.Withdraw: return 'withdraw';
     case TxType.BridgeDeposit: return 'bridge-deposit';
   }
+}
+
+export function estimateCalldataLength(txType: TxType, notesCnt: number, extraDataLen: number = 0): number {
+  let txSpecificLen = 0;
+  switch (txType) {
+    case TxType.Deposit:
+      txSpecificLen = CALLDATA_MEMO_APPROVE_DEPOSIT_BASE_LENGTH + CALLDATA_DEPOSIT_SIGNATURE_LENGTH;
+      break;
+
+    case TxType.BridgeDeposit:
+      txSpecificLen = CALLDATA_MEMO_DEPOSIT_BASE_LENGTH + CALLDATA_DEPOSIT_SIGNATURE_LENGTH;
+      break;
+
+    case TxType.Transfer:
+      txSpecificLen = CALLDATA_MEMO_TRANSFER_BASE_LENGTH + notesCnt * CALLDATA_MEMO_NOTE_LENGTH;
+      break;
+
+    case TxType.Withdraw:
+      txSpecificLen = CALLDATA_MEMO_WITHDRAW_BASE_LENGTH;
+      break;
+  }
+
+  return CALLDATA_BASE_LENGTH + txSpecificLen + extraDataLen;
 }
 
 /** The universal transaction data format used on most networks. */

--- a/src/tx.ts
+++ b/src/tx.ts
@@ -46,7 +46,7 @@ export function estimateCalldataLength(txType: TxType, notesCnt: number, extraDa
       break;
 
     case TxType.Transfer:
-      txSpecificLen = CALLDATA_MEMO_TRANSFER_BASE_LENGTH + notesCnt * CALLDATA_MEMO_NOTE_LENGTH;
+      txSpecificLen = CALLDATA_MEMO_TRANSFER_BASE_LENGTH;
       break;
 
     case TxType.Withdraw:
@@ -54,7 +54,7 @@ export function estimateCalldataLength(txType: TxType, notesCnt: number, extraDa
       break;
   }
 
-  return CALLDATA_BASE_LENGTH + txSpecificLen + extraDataLen;
+  return CALLDATA_BASE_LENGTH + txSpecificLen + extraDataLen + notesCnt * CALLDATA_MEMO_NOTE_LENGTH;
 }
 
 /** The universal transaction data format used on most networks. */


### PR DESCRIPTION
#### This PR made to support dynamic fee calculation. The main changes:
- adapted to the new universal `/fee` relayer endpoint (more details and description: https://github.com/zkBob/zeropool-relayer/pull/172)
- introduced new fee structure `RelayerFee = { fee: bigint, oneByteFee: bigint}`
- the client's method `getRelayerFee` becomes public and returns `RelayerFee` object (instead absolute fee value)
- the client's method `atomicTxFee` now depends on txType argument (evaluates typical tx fee absolute value based on actual relayer fee response)
- all transaction methods (`depositPermittable`, `depositPermittableEphemeral`, `transferMulti`, `withdrawMulti` and `deposit`) and `getTransactionParts` get optional relayerFee argument of `RelayerFee` type instead old absolute fee value (old `feeGwei` parameter). In case of `relayerFee` omitted the actual fee will be fetched from the relayer automatically. Absolute fee will always calculated under-the-hood
- `FeeAmount` object (returned by `feeEstimate` method) was changed. The fields `totalPerTx`, `relayer` and  `l1` were removed. The fields `calldataTotalLength` (`number`, calldata length of all txs) and `relayerFee` (`RelayerFee`, fee from relayer which was used to calculations) were added
- `calcMaxAvailableTransfer` and `getTransactionParts` methods now get `TxType` as a first parameter (`TxType.Transfer` and `TxType.Withdraw` are only accessible here)
- `feeDecimals` optional field (`number`) was added in the `Pool` object which passed to the library during initialization. If it's defined, the fee returned by fee-calculation methods (`atomicTxFee`, `feeEstimate`, `getTransactionParts`) will rounded to the specified digits count after the decimal point

You can test this branch and look for the library integration example in the associated console PR: https://github.com/zkBob/zkbob-console/pull/82