### PR TITLE
Fixed bug with incorrect return type in `maxSupportedTokenSwap`

### DIFF
--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -346,7 +346,7 @@ export class ZkBobProvider {
                 cachedAmount = {amount, timestamp: Date.now()};
                 this.maxSwapAmount[this.curPool] = cachedAmount;
             } catch (err) {
-                const res = this.maxSwapAmount[this.curPool]?.amount ?? 0;
+                const res = this.maxSwapAmount[this.curPool]?.amount ?? 0n;
                 console.warn(`Cannot fetch max available swap amount, will using default (${res}): ${err}`);
 
                 return res;


### PR DESCRIPTION
The method `maxSupportedTokenSwap` returned a `number` zero instead a `BigInt` zero (in case of fallback when relayer doesn't support `/maxSupportedTokenSwap` endpoint). Now it's fixed