### PR TITLE
Added support for USDC signatures for mainnet deployments

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ export enum DepositType {
   Approve = 'approve',  // deprecated but still supported deposit scheme
   SaltedPermit = 'permit',  // based on EIP-2612 (salt was added to the signing message)
   PermitV2 = 'permit2',   // Uniswap Permit2 scheme (used for WETH)
+  AuthUSDC = 'usdc',   // EIP-3009 (for most of USDC deployments)
   AuthPolygonUSDC = 'usdc-polygon',  // EIP-3009 (used by USDC token on Polygon)
 }
 

--- a/src/signers/signer-factory.ts
+++ b/src/signers/signer-factory.ts
@@ -4,7 +4,7 @@ import { DepositSigner } from "./abstract-signer";
 import { ApproveSigner } from "./approve-signer";
 import { DepositPermitSigner } from "./permit-signer";
 import { DepositPermit2Signer } from "./permit2-signer";
-import { PolygonUSDCSigner } from "./usdc-signer";
+import { USDCSigner, PolygonUSDCSigner } from "./usdc-signer";
 
 export class DepositSignerFactory {
     static createSigner(network: NetworkBackend, type: DepositType): DepositSigner {
@@ -17,6 +17,9 @@ export class DepositSignerFactory {
 
             case DepositType.PermitV2:
                 return new DepositPermit2Signer(network);
+
+            case DepositType.AuthUSDC:
+                return new USDCSigner(network);
 
             case DepositType.AuthPolygonUSDC:
                 return new PolygonUSDCSigner(network);


### PR DESCRIPTION
In continuation of the previous PR's conversation (https://github.com/zkBob/zkbob-client-js/pull/140#discussion_r1234881055) I added support for USDC pools deployed on the mainnet and other chains.
- `USDCSigner` class added
- `DepositType.AuthUSDC`  ( ==  `usdc`) config type added