### PR TITLE
Negative denominator support

### DIFF
--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -234,9 +234,9 @@ export class ZkBobProvider {
             try {
                 const pool = this.pool();
                 denominator = await this.network().getDenominator(pool.poolAddress);
-                const negMask = 1n << 255n;
-                if (denominator & negMask) {
-                    denominator = -denominator;
+                const negFlag = 1n << 255n;
+                if (denominator & negFlag) {
+                    denominator = -(denominator ^ negFlag);
                 }
                 this.poolDenominators[this.curPool] = denominator;
             } catch (err) {
@@ -322,13 +322,13 @@ export class ZkBobProvider {
     // Convert native pool amount to the base units
     public async shieldedAmountToWei(amountShielded: bigint): Promise<bigint> {
         const denominator = await this.denominator();
-        return denominator > 0 ? amountShielded * denominator : amountShielded / denominator;
+        return denominator > 0 ? amountShielded * denominator : amountShielded / (-denominator);
     }
     
     // Convert base units to the native pool amount
     public async weiToShieldedAmount(amountWei: bigint): Promise<bigint> {
         const denominator = await this.denominator();
-        return denominator > 0 ? amountWei / denominator : amountWei * denominator;
+        return denominator > 0 ? amountWei / denominator : amountWei * (-denominator);
     }
 
     // Round up the fee if needed with fixed fee decimal places (after point)

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -234,6 +234,10 @@ export class ZkBobProvider {
             try {
                 const pool = this.pool();
                 denominator = await this.network().getDenominator(pool.poolAddress);
+                const negMask = 1n << 255n;
+                if (denominator & negMask) {
+                    denominator = -denominator;
+                }
                 this.poolDenominators[this.curPool] = denominator;
             } catch (err) {
                 console.error(`Cannot fetch denominator value from the pool contract: ${err}`);
@@ -318,13 +322,13 @@ export class ZkBobProvider {
     // Convert native pool amount to the base units
     public async shieldedAmountToWei(amountShielded: bigint): Promise<bigint> {
         const denominator = await this.denominator();
-        return amountShielded * denominator;
+        return denominator > 0 ? amountShielded * denominator : amountShielded / denominator;
     }
     
     // Convert base units to the native pool amount
     public async weiToShieldedAmount(amountWei: bigint): Promise<bigint> {
         const denominator = await this.denominator();
-        return amountWei / denominator;
+        return denominator > 0 ? amountWei / denominator : amountWei * denominator;
     }
 
     // Round up the fee if needed with fixed fee decimal places (after point)

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -335,7 +335,10 @@ export class ZkBobProvider {
     protected async roundFee(fee: bigint): Promise<bigint> {
         const feeDecimals = this.pool().feeDecimals;
         if (feeDecimals !== undefined) {
-            const denomLog = (await this.denominator()).toString().length - 1;
+            const denominator = await this.denominator();
+            const denomLog = denominator > 0 ? 
+                        denominator.toString().length - 1 :
+                        -((-denominator).toString().length - 1);
             const poolResDigits = (await this.decimals()) - denomLog;
             if (poolResDigits > feeDecimals) {
                 const rounder = 10n ** BigInt(poolResDigits - feeDecimals);

--- a/src/ephemeral.ts
+++ b/src/ephemeral.ts
@@ -44,7 +44,7 @@ export class EphemeralPool {
     private web3: Web3;
     private token: Contract;
     private rpcUrl: string;
-    private poolDenominator: bigint; // we represent all amounts in that library as in pool (Gwei currently)
+    private poolDenominator: bigint; // we represent all amounts in that library as in pool
 
     // save last scanned address to decrease scan time
     private startScanIndex = 0;
@@ -333,22 +333,22 @@ export class EphemeralPool {
         return existing;
     }
 
-    // in pool dimension (Gwei)
+    // in pool dimension
     private async getNativeBalance(address: string): Promise<bigint> {
         const result = await this.web3.eth.getBalance(address);
         
         return this.poolDenominator > 0 ? 
                 BigInt(result) / this.poolDenominator :
-                BigInt(result) * this.poolDenominator;
+                BigInt(result) * (-this.poolDenominator);
     }
     
-    // in pool dimension (Gwei)
+    // in pool dimension
     private async getTokenBalance(address: string): Promise<bigint> {
         const result = await this.token.methods.balanceOf(address).call();
         
         return this.poolDenominator > 0 ?
                 BigInt(result) / this.poolDenominator :
-                BigInt(result) * this.poolDenominator;
+                BigInt(result) * (-this.poolDenominator);
     }
 
     // number of outgoing transfers via permit

--- a/src/ephemeral.ts
+++ b/src/ephemeral.ts
@@ -337,9 +337,7 @@ export class EphemeralPool {
     private async getNativeBalance(address: string): Promise<bigint> {
         const result = await this.web3.eth.getBalance(address);
         
-        return this.poolDenominator > 0 ? 
-                BigInt(result) / this.poolDenominator :
-                BigInt(result) * (-this.poolDenominator);
+        return BigInt(result);
     }
     
     // in pool dimension

--- a/src/ephemeral.ts
+++ b/src/ephemeral.ts
@@ -337,14 +337,18 @@ export class EphemeralPool {
     private async getNativeBalance(address: string): Promise<bigint> {
         const result = await this.web3.eth.getBalance(address);
         
-        return BigInt(result) / this.poolDenominator;
+        return this.poolDenominator > 0 ? 
+                BigInt(result) / this.poolDenominator :
+                BigInt(result) * this.poolDenominator;
     }
     
     // in pool dimension (Gwei)
     private async getTokenBalance(address: string): Promise<bigint> {
         const result = await this.token.methods.balanceOf(address).call();
         
-        return BigInt(result) / this.poolDenominator;
+        return this.poolDenominator > 0 ?
+                BigInt(result) / this.poolDenominator :
+                BigInt(result) * this.poolDenominator;
     }
 
     // number of outgoing transfers via permit


### PR DESCRIPTION
To support pool migration (BOB -> USDC) the negative denominators should supported by library. The denominator with 1 in MSB considered to be a negative. And we should multiple native amount to get the pool resolution (instead dividing)

There are any changes in the library interfaces and method signatures

Please use the corresponding console branch to check it https://github.com/zkBob/zkbob-console/pull/88