### PR TITLE
Added ability to redeem gift-card for the specified value

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -910,7 +910,7 @@ export class ZkBobClient extends ZkBobProvider {
   // Transfer shielded tokens from the gift-card account to the current account
   // NOTE: for simplicity we assume the multitransfer doesn't applicable for gift-cards
   // (i.e. any redemption can be done in a single transaction)
-  public async redeemGiftCard(giftCard: GiftCardProperties, prefferedProvingMode?: ProverMode): Promise<string> {
+  public async redeemGiftCard(giftCard: GiftCardProperties, preferredProvingMode?: ProverMode): Promise<string> {
     if (!this.account) {
       throw new InternalError(`Cannot redeem gift card to the uninitialized account`);
     }
@@ -922,7 +922,7 @@ export class ZkBobClient extends ZkBobProvider {
         sk: giftCard.sk,
         pool: giftCard.poolAlias,
         birthindex: giftCard.birthIndex,
-        proverMode: prefferedProvingMode ?? this.getProverMode(),
+        proverMode: preferredProvingMode ?? this.getProverMode(),
     }
     
     const accId = accountId(giftCardAcc);

--- a/src/client.ts
+++ b/src/client.ts
@@ -935,6 +935,10 @@ export class ZkBobClient extends ZkBobProvider {
 
     const bigIntMin = (...args) => args.reduce((m, e) => e < m ? e : m);
     const redeemAmount =  bigIntMin((giftCardBalance - minFee), giftCard.balance);
+    if (redeemAmount < giftCard.balance) {
+      console.error(`Gift card: redeem amount ${redeemAmount} is less than card value ${giftCard.balance} (actual card balance: ${giftCardBalance}). SupportID: ${this.supportId}`);
+    }
+
     const dstAddr = await this.generateAddress(); // getting address from the current account
     const actualFee = giftCardBalance - redeemAmount; // fee can be greater than needed to make redemption amount equals to nominal
     const oneTx: ITransferData = {


### PR DESCRIPTION
The gift-card redemption amount now aligned with the specified card nominal
- functions `redeemGiftCard` and `giftCardBalance` now get `GiftCardProperties` as a parameter (instead `AccountConfig`)
- preferred prover mode which will using for redemption process can be specified as a second parameter for `redeemGiftCard` (optional)

Associated issue: https://github.com/zkBob/zkbob-client-js/issues/135
Associated console PR: https://github.com/zkBob/zkbob-console/pull/89