### PR TITLE
Parsing extended relayer fee format

### DIFF
--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -255,7 +255,10 @@ export class ZkBobRelayer implements IZkBobService {
         },
         oneByteFee: BigInt(res.oneByteFee ?? '0')
       };
-    } else if (typeof feeResp === 'string') {
+    } else if (typeof feeResp === 'string' || 
+                typeof feeResp === 'number' ||
+                typeof feeResp === 'bigint'
+    ) {
       return {
         fee: {
           deposit: BigInt(feeResp),


### PR DESCRIPTION
The changes are introduced in order to parse new relayer fee endpoint. The new endpoint `/fee/v2` will return the following json:

```
 {
  fee: {
    deposit: string;
    transfer: string;
    withdrawal: string;
    permittableDeposit: string;
  };
  oneByteFee: string;
}
```

So the library should distinguish the base fee component for the different transaction types