### PR TITLE
State updating progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/client.ts
+++ b/src/client.ts
@@ -213,6 +213,7 @@ export class ZkBobClient extends ZkBobProvider {
       const state = await ZkBobState.create(
           this.account.sk,
           this.account.birthindex,
+          network,
           networkName,
           network.getRpcUrl(),
           denominator,

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,7 +26,6 @@ import { wrap } from 'comlink';
 import { PreparedTransaction } from './networks/network';
 import { Privkey } from 'hdwallet-babyjub';
 import { IDBPDatabase, openDB } from 'idb';
-import { stat } from 'fs';
 
 const OUTPLUSONE = CONSTANTS.OUT + 1; // number of leaves (account + notes) in a transaction
 const PARTIAL_TREE_USAGE_THRESHOLD = 500; // minimum tx count in Merkle tree to partial tree update using
@@ -1601,7 +1600,6 @@ export class ZkBobClient extends ZkBobProvider {
       const poolAddr = this.pool().poolAddress;
       const statTime = await this.statDb.get(SYNC_PERFORMANCE, poolAddr);
       if (typeof statTime === 'number') {
-        console.log(`[PoolPerformance]: using saved performance ${statTime} ms\\tx`);
         return statTime;
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1613,10 +1613,11 @@ export class ZkBobClient extends ZkBobProvider {
 
       const statTime = await this.statDb.get(SYNC_PERFORMANCE, poolAddr);
       if (typeof statTime === 'number') {
-        // if stat already exist for that pool - update performace just in case of full sync  
+        // if stat already exist for that pool - set new performace just in case of full sync
+        // Set the mean performance (saved & current) when the full sync stat isn't available
         await this.statDb.put(SYNC_PERFORMANCE, fullSyncTime ?? ((allSyncTime + statTime) / 2), poolAddr);
       } else {
-        // if no sync exist - set the mean time (saved & current)
+        // if no statistic exist - set current avg sync time (full sync is always prioritized)
         await this.statDb.put(SYNC_PERFORMANCE, fullSyncTime ?? allSyncTime, poolAddr);
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1657,13 +1657,12 @@ export class ZkBobClient extends ZkBobProvider {
 
   // synthetic benchmark, result in microseconds per tx
   private async estimateSyncSpeed(samplesNum: number = 1000): Promise<number> {
-    //const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
     const sk = bigintToArrayLe(Privkey("test test test test test test test test test test test tell", "m/0'/0'"));
     const samples = Array.from({length: samplesNum}, (_value, index) => index * (CONSTANTS.OUT + 1));
     const txs: IndexedTx[] = samples.map((index) => {
       return {
         index,
-        memo: '02000000ff73d841b6d0027b689346b50aee18ef8263e2a27b0da325aba9774c46ffd4000d2e19298339b722fa126acedf1bcb300ebe0f8a0e96589b0c92612c96346d0db314014936ed9f11a60f15de2704dfa3f0a735242720637e0136d9b79d06342de5604968cb42d9ba3f57d9c2a591d1ca448e1f24b675b9de375f2086a6f17fd35c5e6318e0694d7bddce27e259acdb03e5943fa1f794149fadd45b3fcb15e7d9e0b16eefae48e2221bb405fd0ced6baf1d09baa042b864d7c73c7d642d8b143903d4f434ce811eb25bc4b988202318e16fbe15e259a5a7636d2713c0bee2b9579901fe559e4dde2be00b723843decaa18febc1b48a349b9f4c29074692c5af0c8a828df1f8e8f9fd8d7d752470bb63f132892f7669d5a305460b6c4c1ac76d0fc2ee164eae1c30ee8ea9ec666296c0d7e205386d1cf8356e88bc8ebb5786ed47bca1910598ea1e2adbae1663b90b00697d4f499e1955fd05c998be29dd9824dccc20e47fc1c81e3e13e20e9fda4e21514a5d', //`01000000${'00'.repeat(CALLDATA_MEMO_TRANSFER_BASE_LENGTH + CALLDATA_MEMO_NOTE_LENGTH - 8)}`,
+        memo: '02000000ff73d841b6d0027b689346b50aee18ef8263e2a27b0da325aba9774c46ffd4000d2e19298339b722fa126acedf1bcb300ebe0f8a0e96589b0c92612c96346d0db314014936ed9f11a60f15de2704dfa3f0a735242720637e0136d9b79d06342de5604968cb42d9ba3f57d9c2a591d1ca448e1f24b675b9de375f2086a6f17fd35c5e6318e0694d7bddce27e259acdb03e5943fa1f794149fadd45b3fcb15e7d9e0b16eefae48e2221bb405fd0ced6baf1d09baa042b864d7c73c7d642d8b143903d4f434ce811eb25bc4b988202318e16fbe15e259a5a7636d2713c0bee2b9579901fe559e4dde2be00b723843decaa18febc1b48a349b9f4c29074692c5af0c8a828df1f8e8f9fd8d7d752470bb63f132892f7669d5a305460b6c4c1ac76d0fc2ee164eae1c30ee8ea9ec666296c0d7e205386d1cf8356e88bc8ebb5786ed47bca1910598ea1e2adbae1663b90b00697d4f499e1955fd05c998be29dd9824dccc20e47fc1c81e3e13e20e9fda4e21514a5d', 
         commitment: '0bc0c8fe774470d73f8695bd60aa3de479ce516e357d07f3e120ca8534cebd26'
       }
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1463,12 +1463,16 @@ export class ZkBobClient extends ZkBobProvider {
   // Request the latest state from the relayer
   // Returns isReadyToTransact flag
   public async updateState(): Promise<boolean> {
-    return await this.zpState().updateState(
+    this.setState(ClientState.StateUpdating);
+    
+    const res = await this.zpState().updateState(
       this.relayer(),
       async (index) => (await this.getPoolState(index)).root,
       await this.coldStorageConfig(),
       this.coldStorageBaseURL(),
     );
+
+    return res;
   }
 
   // ----------------=========< Ephemeral Addresses Pool >=========-----------------

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ const PERMIT_DEADLINE_THRESHOLD = 300;   // minimum time to deadline before tx p
 const CONTINUOUS_STATE_UPD_INTERVAL = 200; // updating client's state timer interval for continuous states (in ms)
 const CONTINUOUS_STATE_THRESHOLD = 1000;  // the state considering continuous after that interval (in ms)
 
-// Common databasse table's name
+// Common database table's name
 const SYNC_PERFORMANCE = 'SYNC_PERFORMANCE';
 
 // Transfer destination + amount
@@ -87,7 +87,7 @@ export enum ClientState {
   StateUpdatingContinuous,  // sync which takes longer than threshold
   HistoryUpdating,
 }
-const continuosStates = [ ClientState.StateUpdatingContinuous ];
+const continuousStates = [ ClientState.StateUpdatingContinuous ];
 
 export type ClientStateCallback = (state: ClientState, progress?: number) => void;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1480,13 +1480,6 @@ export class ZkBobClient extends ZkBobProvider {
   public async updateState(): Promise<boolean> {
     this.setState(ClientState.StateUpdating);
 
-    const updPromise = this.zpState().updateState(
-      this.relayer(),
-      async (index) => (await this.getPoolState(index)).root,
-      await this.coldStorageConfig(),
-      this.coldStorageBaseURL(),
-    );
-
     const timePerTx = await this.getPoolAvgTimePerTx(); // process + save in the most cases
     const saveTimePerTx = await this.getAvgSavingTxTime();  // saving time
     let maxShowedProgress = 0;
@@ -1523,7 +1516,12 @@ export class ZkBobClient extends ZkBobProvider {
       }
     }, CONTINUOUS_STATE_UPD_INTERVAL);
 
-    const hasOwnTxsInOptimisticState = await updPromise;
+    const hasOwnTxsInOptimisticState = await this.zpState().updateState(
+      this.relayer(),
+      async (index) => (await this.getPoolState(index)).root,
+      await this.coldStorageConfig(),
+      this.coldStorageBaseURL(),
+    );
 
     clearInterval(timerId);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ export { ClientConfig, AccountConfig, accountId,
         ProverMode, Chain, Pool, Chains, Pools,
         SnarkConfigParams, DepositType
       } from './config';
-export { ZkBobClient, TransferConfig, TransferRequest, FeeAmount } from './client';
+export { ZkBobClient, TransferConfig, TransferRequest, FeeAmount,
+        ClientState, ClientStateCallback
+      } from './client';
 export { ZkBobProvider as ZkBobAccountlessClient, GiftCardProperties } from './client-provider';
 export { SyncStat } from './state';
 export { TxType } from './tx';

--- a/src/state.ts
+++ b/src/state.ts
@@ -23,7 +23,7 @@ const PARTIAL_TREE_USAGE_THRESHOLD = 500; // minimum tx count in Merkle tree to 
 const CORRUPT_STATE_ROLLBACK_ATTEMPTS = 2; // number of state restore attempts (via rollback)
 const CORRUPT_STATE_WIPE_ATTEMPTS = 5; // number of state restore attempts (via wipe)
 const COLD_STORAGE_USAGE_THRESHOLD = 1000;  // minimum number of txs to cold storage using
-const MIN_TX_COUNT_FOR_STAT = 10;
+const MIN_TX_COUNT_FOR_STAT = 100;
 
 
 export interface BatchResult {

--- a/src/state.ts
+++ b/src/state.ts
@@ -800,12 +800,8 @@ export class ZkBobState {
                   return new Uint8Array(aBulk);
                 }
 
-                //console.warn(`🧊[ColdSync] cannot load bulk ${bulkInfo.filename}: got ${aBulk.byteLength} bytes, expected ${bulkInfo.bytes} bytes`);
-                //return new Uint8Array();
                 throw new InternalError(`Cold storage corrupted (invalid file size: ${aBulk.byteLength})`)
               } else {
-                //console.warn(`🧊[ColdSync] cannot load bulk ${bulkInfo.filename}: response code ${response.status} (${response.statusText})`);
-                //return new Uint8Array();
                 throw new InternalError(`Couldn't load cold storage (invalid response code: ${response.status})`)
               }
             });

--- a/src/state.ts
+++ b/src/state.ts
@@ -403,6 +403,8 @@ export class ZkBobState {
         }
       }, initRes);
 
+      const startSavingTime = Date.now();
+      console.log(`🔥[HotSync] all batches were processed. Saving...`);
       // Saving parsed transaction from the hot sync in the local Merkle tree
       const idxs = [...totalRes.state.keys()].sort((i1, i2) => i1 - i2);
       for (const idx of idxs) {
@@ -425,6 +427,8 @@ export class ZkBobState {
           throw new InternalError(`Cannot find state batch at index ${idx}`);
         }
       }
+
+      console.log(`🔥[HotSync] Saved local state in ${Date.now() - startSavingTime} ms`);
 
       // remove unneeded pending records
       this.history?.setLastMinedTxIndex(totalRes.maxMinedIndex);
@@ -503,9 +507,9 @@ export class ZkBobState {
   private async startHotSync(relayer: ZkBobRelayer, fromIndex: number, toIndex: number): Promise<BatchResult[]> {
     let hotSyncPromises: Promise<BatchResult>[] = [];
     for (let i = fromIndex; i <= toIndex; i = i + BATCH_SIZE * OUTPLUSONE) {
-      hotSyncPromises.push(this.fetchBatch(relayer, i, BATCH_SIZE).then(async (aBatch) => {
+      hotSyncPromises.push(this.fetchBatch(relayer, i, BATCH_SIZE).then((aBatch) => {
         // batch fetched, let's parse it!
-        return await this.parseBatch(aBatch);
+        return this.parseBatch(aBatch);
       }));
     }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -505,12 +505,7 @@ export class ZkBobState {
     for (let i = fromIndex; i <= toIndex; i = i + BATCH_SIZE * OUTPLUSONE) {
       hotSyncPromises.push(this.fetchBatch(relayer, i, BATCH_SIZE).then(async (aBatch) => {
         // batch fetched, let's parse it!
-        const startParseTime = Date.now();
-        const result = await this.parseBatch(aBatch);
-        const parseTime = (Date.now() - startParseTime) / 1000;
-        console.log(`Parsed: ${aBatch.count} transactions from index ${aBatch.fromIndex} [${parseTime.toFixed(2)} sec]`);
-
-        return result;
+        return await this.parseBatch(aBatch);
       }));
     }
 
@@ -519,7 +514,6 @@ export class ZkBobState {
 
   // Get the transactions from the relayer starting from the specified index
   private async fetchBatch(relayer: ZkBobRelayer, fromIndex: number, count: number): Promise<RawTxsBatch> {
-    const startDownloadTime = Date.now();
     return relayer.fetchTransactionsOptimistic(BigInt(fromIndex), count).then( async txs => {      
       const txHashes: Record<number, string> = {};
       const indexedTxs: IndexedTx[] = [];
@@ -556,8 +550,7 @@ export class ZkBobState {
         }
       }
 
-      const downloadTime = (Date.now() - startDownloadTime) / 1000;
-      console.log(`🔥[HotSync] got batch of ${txs.length} transactions from index ${fromIndex} in ${downloadTime.toFixed(2)} sec`);
+      console.log(`🔥[HotSync] got batch of ${txs.length} transactions from index ${fromIndex}`);
 
       return {
         fromIndex: fromIndex,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -182,10 +182,12 @@ const obj = {
   },
 
   async updateState(accountId: string, stateUpdate: StateUpdate, siblings?: TreeNode[]): Promise<void> {
+    console.debug('Web worker: updateState');
     return zpAccounts[accountId].updateState(stateUpdate, siblings);
   },
 
   async updateStateColdStorage(accountId: string, bulks: Uint8Array[], indexFrom?: bigint, indexTo?: bigint): Promise<ParseTxsColdStorageResult> {
+    console.debug('Web worker: updateStateColdStorage');
     return zpAccounts[accountId].updateStateColdStorage(bulks, indexFrom, indexTo);
   },
 


### PR DESCRIPTION
The following changes helps to display approximately state syncing progress in the UI by providing a callback.
You  can add your callback during the library initializing or any time by setting `stateCallback` client's optional property of type:
```
type ClientStateCallback = (state: ClientState, progress?: number) => void
```

The callback will be invoked on state changing. For continuous modes `progress` field will be fulfilled. The following states are currently supported:
```
export enum ClientState {
  Initializing = 0,
  AccountlessMode,
  SwitchingPool,
  AttachingAccount,
  // the following routines belongs to the full mode
  FullMode, // ready to operate
  StateUpdating,  // short state sync
  StateUpdatingContinuous,  // sync which takes longer than threshold (1 s currently)
  HistoryUpdating,
}
```
Due to low state sync progress precision there are two states for state updating: short and continuous. The short state will transform to the continuous state after the hard-coded threshold (1 second for now). It avoid displaying progress for the short updates where the progress counter is most inaccurate. 

The progress estimation is pretty complex:
- it use the saved synchronization statistics for the current pool to estimate sync time
- if it doesn't exist the synthetic test will performed to predict approximately speed of the wasm engine
- we also get the actual number processed transaction and adjust overall progress with it (but there are a lot of factors including cold storage configuration which leads that value increased very uneven)
- the asymptotic function applies when estimating progress by time to smooth inaccuracies

The following issues are still non-solved with the current approach (and most likely will not be solved):
- The progress will never be decreased. Instead it will moving to the 100% in asymptotic manner (it's a trade-off for combination time estimation with the number of processed transactions in fact)
- We cannot know before the syncing how many notes contained in the transactions batch. That's why the sync progress might be very uneven when a lot of multitransfer transactions included in the privacy pool (e.g. for the `BOB-sepolia` pool). To solve it the saved sync performance is adaptive
- There is another stage for account syncing - getting the history. It's a strongly unpredictable process depended on history length, RPC delays and others. In the most cases history sync in several (0-3) seconds. But in case of huge history that time may be significantly increased. Currently history updating is non-continuous state (without a progress). I tried to estimate history syncing progress but cannot implement it in smooth manner


You can check sync progress with the associated console version https://github.com/zkBob/zkbob-console/pull/94
(use `sync` CLI command to show a progress)

The staging console was deployed with beta version of the library built from that branch
<img width="323" alt="image" src="https://github.com/zkBob/zkbob-client-js/assets/1415489/e8015e28-6672-4a8c-bfe4-b3d04eb3cfbb">
