### PR TITLE
Fixed withdrawal address in history for Tron networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -788,9 +788,10 @@ export class EvmNetwork extends MultiRpcManager implements NetworkBackend, RpcMa
                                 throw new InternalError(`No signature for approve deposit`);
                             }
                         } else if (tx.txType == RegularTxType.BridgeDeposit) {
-                            txInfo.depositAddr = '0x' + tx.memo.slice(32, 72);
+                            
+                            txInfo.depositAddr = this.bytesToAddress(hexToBuf(tx.memo.slice(32, 72), 20));
                         } else if (tx.txType == RegularTxType.Withdraw) {
-                            txInfo.withdrawAddr = '0x' + tx.memo.slice(32, 72);
+                            txInfo.withdrawAddr = this.bytesToAddress(hexToBuf(tx.memo.slice(32, 72), 20));
                         }
 
                         return {

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -788,7 +788,6 @@ export class EvmNetwork extends MultiRpcManager implements NetworkBackend, RpcMa
                                 throw new InternalError(`No signature for approve deposit`);
                             }
                         } else if (tx.txType == RegularTxType.BridgeDeposit) {
-                            
                             txInfo.depositAddr = this.bytesToAddress(hexToBuf(tx.memo.slice(32, 72), 20));
                         } else if (tx.txType == RegularTxType.Withdraw) {
                             txInfo.withdrawAddr = this.bytesToAddress(hexToBuf(tx.memo.slice(32, 72), 20));

--- a/src/networks/tron/index.ts
+++ b/src/networks/tron/index.ts
@@ -722,9 +722,9 @@ export class TronNetwork extends MultiRpcManager implements NetworkBackend, RpcM
                             throw new InternalError(`No signature for approve deposit`);
                         }
                     } else if (tx.txType == RegularTxType.BridgeDeposit) {
-                        txInfo.depositAddr = '0x' + tx.memo.slice(32, 72);
+                        txInfo.depositAddr = this.bytesToAddress(hexToBuf(tx.memo.slice(32, 72), 20));
                     } else if (tx.txType == RegularTxType.Withdraw) {
-                        txInfo.withdrawAddr = '0x' + tx.memo.slice(32, 72);
+                        txInfo.withdrawAddr = this.bytesToAddress(hexToBuf(tx.memo.slice(32, 72), 20));
                     }
 
                     return {


### PR DESCRIPTION
Here is a hotfix for Tron networks. The bug was discovered during public testing on the Nile network. Withdrawal addresses were parsed incorrectly during history retrieval

<img width="384" alt="image" src="https://github.com/zkBob/zkbob-client-js/assets/1415489/b73d9376-6e6b-4bc2-898f-59107b2954e9">
