### PR TITLE
MPC Guard Support

### DIFF
--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -373,7 +373,7 @@ export class ZkBobProvider {
         throw new InternalError(`The current pool (id = 0x${poolId.toString(16)}) has no configured address prefix`);
     }
 
-    public depositDestination(): string {
+    public async depositDestination(): Promise<string> {    // promise for future possible dynamic config
         const pool = this.pool();
         
         return pool.guardAddress ?? pool.poolAddress;

--- a/src/client-provider.ts
+++ b/src/client-provider.ts
@@ -373,6 +373,12 @@ export class ZkBobProvider {
         throw new InternalError(`The current pool (id = 0x${poolId.toString(16)}) has no configured address prefix`);
     }
 
+    public depositDestination(): string {
+        const pool = this.pool();
+        
+        return pool.guardAddress ?? pool.poolAddress;
+    }
+
     // -------------=========< Converting Amount Routines >=========---------------
     // | Between wei and pool resolution                                          |
     // ----------------------------------------------------------------------------

--- a/src/client.ts
+++ b/src/client.ts
@@ -841,7 +841,7 @@ export class ZkBobClient extends ZkBobProvider {
     const dataToSign: DepositData = {
       tokenAddress: pool.tokenAddress,
       owner: fromAddress,
-      spender: this.depositDestination(),
+      spender: await this.depositDestination(),
       amount: await this.shieldedAmountToWei(amountGwei + feeGwei),
       deadline: BigInt(deadline),
       nullifier: '0x' + toTwosComplementHex(BigInt(txData.public.nullifier), 32)
@@ -920,7 +920,7 @@ export class ZkBobClient extends ZkBobProvider {
     }
 
     if (pool.depositScheme == DepositType.PermitV2 || pool.depositScheme == DepositType.Approve) {
-      const spender = pool.depositScheme == DepositType.PermitV2 ? PERMIT2_CONTRACT : this.depositDestination();
+      const spender = pool.depositScheme == DepositType.PermitV2 ? PERMIT2_CONTRACT : await this.depositDestination();
       const curAllowance = await state.ephemeralPool().allowance(ephemeralIndex, spender);
       if (curAllowance < amountGwei + neededFee.total) {
         console.log(`Approving tokens for contract ${spender}...`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -841,7 +841,7 @@ export class ZkBobClient extends ZkBobProvider {
     const dataToSign: DepositData = {
       tokenAddress: pool.tokenAddress,
       owner: fromAddress,
-      spender: pool.poolAddress,
+      spender: this.depositDestination(),
       amount: await this.shieldedAmountToWei(amountGwei + feeGwei),
       deadline: BigInt(deadline),
       nullifier: '0x' + toTwosComplementHex(BigInt(txData.public.nullifier), 32)
@@ -920,7 +920,7 @@ export class ZkBobClient extends ZkBobProvider {
     }
 
     if (pool.depositScheme == DepositType.PermitV2 || pool.depositScheme == DepositType.Approve) {
-      const spender = pool.depositScheme == DepositType.PermitV2 ? PERMIT2_CONTRACT : pool.poolAddress;
+      const spender = pool.depositScheme == DepositType.PermitV2 ? PERMIT2_CONTRACT : this.depositDestination();
       const curAllowance = await state.ephemeralPool().allowance(ephemeralIndex, spender);
       if (curAllowance < amountGwei + neededFee.total) {
         console.log(`Approving tokens for contract ${spender}...`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export interface Pool {
   isNative?: boolean;
   ddSubgraph?: string;
   parameters?: string;
+  guardAddress?: string,
 }
 
 export enum ProverMode {


### PR DESCRIPTION
The following changes are introduced to support transactioning via MPCGuard:
- added optional property `guardAddress` to the `Pool` config object (it will use to approve tokens\ and making permit signatures in case of `MPCGuard` contract environment)
- added public function `ZkBobClient.depositDestination()` to retrieve deposit spender from the application side (e.g. to make token approval in case of `approve` deposit scheme)
- permit deposit will be signed for `guardAddress` if configured

Associated console PR: https://github.com/zkBob/zkbob-console/pull/102