### PR TITLE
Tronweb apikey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "5.5.3-beta1",
+  "version": "5.5.3",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "5.5.2",
+  "version": "5.5.3-beta1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",

--- a/src/networks/tron/index.ts
+++ b/src/networks/tron/index.ts
@@ -64,9 +64,16 @@ export class TronNetwork extends MultiRpcManager implements NetworkBackend, RpcM
     public setEnabled(enabled: boolean) {
         if (enabled) {
             if (!this.isEnabled()) {
+                let optKey;
+                try {
+                    optKey = (process as any)?.env?.REACT_APP_TRONGRID_API_KEY ?? 
+                            (window as any)?.REACT_APP_TRONGRID_API_KEY;
+                } catch(_) {}
+
                 this.tronWeb = new TronWeb({
                     fullHost: this.curRpcUrl(),
                     privateKey: '01',
+                    headers: optKey ? { 'TRON-PRO-API-KEY': optKey } : undefined,
                 });
             }
         } else {


### PR DESCRIPTION
Added ability to bring Tron RPC API key through the environment variable `process.env.REACT_APP_TRONGRID_API_KEY` or `window.REACT_APP_TRONGRID_API_KEY`