### PR TITLE
Fix/history sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",


### PR DESCRIPTION
Fixed an issue related to history synchronization. The `txHash` of a commit transaction can change due to the sequencer resend mechanism. In this case, the `/transaction/v2` endpoint may contain an outdated `txHash` for the transaction, which could lead to the associated history record eventually disappearing. This PR solves the issue by maintaining a mapping between the `txHash` and the `HistoryRecord` until the transaction is included in the Merkle tree.

**NOTE:** This is just a hotfix. The best approach would be to introduce a `commitment` -> `HistoryRecord` mapping. However this requires modifying the `libzkbob-rs` library to append the commitment field to the `DecryptedMemo`. It may be addressed during future refactoring.