### PR TITLE
Selecting random sequencer in case of equal fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-client-js",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "zkBob integration library",
   "repository": "git@github.com:zkBob/libzkbob-client-js.git",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",


### PR DESCRIPTION
Here is a small fix aimed at balancing the load on sequencers in cases where fees are the same. If multiple proxies meet the minimum fee criteria, a random one will be chosen among them.